### PR TITLE
fix: ordered_at value

### DIFF
--- a/src/Order.php
+++ b/src/Order.php
@@ -138,7 +138,7 @@ class Order extends Model // @phpstan-ignore-line propertyTag.trait - Billable i
             'customer_id' => $attributes['customer_id'],
             'product_id' => $attributes['product_id'],
             'refunded_at' => $attributes['refunded_at'],
-            'ordered_at' => $attributes['ordered_at'],
+            'ordered_at' => $attributes['created_at'],
         ]);
 
         return $this;


### PR DESCRIPTION
When creating a new order, an error occurs:

```
Undefined array key "ordered_at" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"ordered_at\" at /app/vendor/danestves/laravel-polar/src/Order.php:141)
```

The `ordered_at` key is not present in the attributes.

This PR changes the code to use `created_at` instead. Is it a valid approach?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the synchronization of order timestamps to ensure the "ordered at" date is now set based on the creation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->