### PR TITLE
Update subscription API method and subscriptionData to match Polar API

### DIFF
--- a/src/Data/Subscriptions/SubscriptionData.php
+++ b/src/Data/Subscriptions/SubscriptionData.php
@@ -121,9 +121,6 @@ class SubscriptionData extends Data
         /** @var array<string, string|int|bool> */
         public readonly array $metadata,
         public readonly CustomerData $customer,
-        /** @deprecated */
-        public readonly string $userId,
-        public readonly UserData $user,
         /**
          * A product.
          */

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -60,7 +60,7 @@ class LaravelPolar
     public static function updateSubscription(string $subscriptionId, SubscriptionUpdateProductData|SubscriptionCancelData $request): SubscriptionData
     {
         try {
-            $response = self::api("POST", "v1/subscriptions/$subscriptionId", $request->toArray());
+            $response = self::api("PATCH", "v1/subscriptions/$subscriptionId", $request->toArray());
 
             return SubscriptionData::from($response->json());
         } catch (PolarApiError $e) {


### PR DESCRIPTION
This PR includes two changes:

1) Updated the request method for updating subscriptions from POST to PATCH to match the Polar docs: https://docs.polar.sh/api-reference/subscriptions/update - This fixes #37 


2) Removed the user properties from SubscriptionData DTO as these are no longer returned by the Polar API and caused the following error:
<img width="1371" height="251" alt="image" src="https://github.com/user-attachments/assets/d585e6f9-1c3f-4028-b81a-c7600dbdf084" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated user and userId fields from subscription data. This is a breaking change: update any code that reads these fields.
  * Streamlined the subscription update request under the hood to better align with the backend API. No changes to how you call the update method, inputs, or outputs.

* **Chores**
  * General maintenance to reduce surface area of the subscription data object and improve request handling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->