### PR TITLE
refactor: convert empty arrays to null in metadata handling methods

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -74,7 +74,7 @@ class Checkout implements Responsable
      */
     public function withMetadata(?array $metadata): self
     {
-        $this->metadata = $metadata;
+        $this->metadata = ($metadata === []) ? null : $metadata;
 
         return $this;
     }
@@ -86,7 +86,7 @@ class Checkout implements Responsable
      */
     public function withCustomFieldData(?array $customFieldData): self
     {
-        $this->customFieldData = $customFieldData;
+        $this->customFieldData = ($customFieldData === []) ? null : $customFieldData;
 
         return $this;
     }
@@ -106,12 +106,15 @@ class Checkout implements Responsable
      */
     public function withCustomerMetadata(?array $customerMetadata): self
     {
-        $this->customerMetadata = $customerMetadata;
-
-        $this->customerMetadata = collect(array_replace_recursive($this->customerMetadata, $customerMetadata))
+        // Process input: trim strings and filter out nulls (defensive programming)
+        $processed = collect($customerMetadata)
             ->map(fn($value) => is_string($value) ? trim($value) : $value)
+            /** @phpstan-ignore-next-line Defensive: filter out nulls even though type doesn't allow them */
             ->filter(fn($value) => $value !== null)
             ->toArray();
+
+        // Convert empty array to null for SDK serialization
+        $this->customerMetadata = ($processed === []) ? null : $processed;
 
         return $this;
     }

--- a/tests/Feature/CheckoutTest.php
+++ b/tests/Feature/CheckoutTest.php
@@ -281,3 +281,80 @@ it('can set all checkout options', function () {
     $allowDiscountCodesProperty->setAccessible(true);
     expect($allowDiscountCodesProperty->getValue($checkout))->toBeFalse();
 });
+
+it('converts empty metadata array to null', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withMetadata([]);
+
+    $reflection = new \ReflectionClass($checkout);
+    $metadataProperty = $reflection->getProperty('metadata');
+    $metadataProperty->setAccessible(true);
+
+    expect($metadataProperty->getValue($checkout))->toBeNull();
+});
+
+it('converts empty custom field data array to null', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withCustomFieldData([]);
+
+    $reflection = new \ReflectionClass($checkout);
+    $customFieldDataProperty = $reflection->getProperty('customFieldData');
+    $customFieldDataProperty->setAccessible(true);
+
+    expect($customFieldDataProperty->getValue($checkout))->toBeNull();
+});
+
+it('converts empty customer metadata array to null', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withCustomerMetadata([]);
+
+    $reflection = new \ReflectionClass($checkout);
+    $customerMetadataProperty = $reflection->getProperty('customerMetadata');
+    $customerMetadataProperty->setAccessible(true);
+
+    expect($customerMetadataProperty->getValue($checkout))->toBeNull();
+});
+
+it('converts customer metadata to null after filtering leaves empty array', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withCustomerMetadata(['key1' => null, 'key2' => null]);
+
+    $reflection = new \ReflectionClass($checkout);
+    $customerMetadataProperty = $reflection->getProperty('customerMetadata');
+    $customerMetadataProperty->setAccessible(true);
+
+    expect($customerMetadataProperty->getValue($checkout))->toBeNull();
+});
+
+it('preserves null metadata input', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withMetadata(null);
+
+    $reflection = new \ReflectionClass($checkout);
+    $metadataProperty = $reflection->getProperty('metadata');
+    $metadataProperty->setAccessible(true);
+
+    expect($metadataProperty->getValue($checkout))->toBeNull();
+});
+
+it('preserves non-empty metadata array', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withMetadata(['key' => 'value']);
+
+    $reflection = new \ReflectionClass($checkout);
+    $metadataProperty = $reflection->getProperty('metadata');
+    $metadataProperty->setAccessible(true);
+
+    expect($metadataProperty->getValue($checkout))->toBe(['key' => 'value']);
+});
+
+it('trims customer metadata string values', function () {
+    $checkout = Checkout::make(['product_123'])
+        ->withCustomerMetadata(['name' => '  John Doe  ']);
+
+    $reflection = new \ReflectionClass($checkout);
+    $customerMetadataProperty = $reflection->getProperty('customerMetadata');
+    $customerMetadataProperty->setAccessible(true);
+
+    expect($customerMetadataProperty->getValue($checkout))->toBe(['name' => 'John Doe']);
+});


### PR DESCRIPTION
- Fixed TypeError when passing empty arrays to `withMetadata()`, `withCustomFieldData()`, or `withCustomerMetadata()` methods in PHP 8.4
- Removed redundant `array_replace_recursive` call in `withCustomerMetadata()` method
- Empty arrays in metadata fields are now properly converted to `null` to align with SDK's serialization expectations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of empty metadata and custom field data arrays during checkout—now converted to null for consistency.
  * Enhanced customer metadata processing with automatic whitespace trimming and null value filtering for cleaner data storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->