### PR TITLE
feat(refunds): issue refunds via $order->refund()

### DIFF
--- a/docs/migration-v2.3-to-v2.4.md
+++ b/docs/migration-v2.3-to-v2.4.md
@@ -1,0 +1,64 @@
+# Migrating from v2.3 to v2.4
+
+`v2.4.0` is **purely additive** — your existing code continues to work without changes.
+
+## What's new
+
+### Issue refunds directly on Orders
+
+Two new methods on `Order`:
+
+```php
+use Polar\Models\Components\RefundReason;
+
+// Full refund of remaining unrefunded amount (defaults to RefundReason::CustomerRequest):
+$refund = $order->refund();
+
+// Partial refund:
+$refund = $order->refund(amount: 2500);
+
+// Fully-customized refund:
+$refund = $order->refund(
+    amount: 2500,
+    reason: RefundReason::Fraudulent,
+    comment: 'flagged by risk team',
+    metadata: ['ticket' => 'T-42'],
+);
+
+// List refunds for this order:
+$refunds = $order->refunds(); // Illuminate\Support\Collection<int, \Polar\Models\Components\Refund>
+```
+
+### Admin-level facade methods
+
+Two new static methods on `LaravelPolar`:
+
+```php
+use Danestves\LaravelPolar\LaravelPolar;
+use Polar\Models\Components;
+use Polar\Models\Operations;
+
+// Create a refund (general-purpose, requires orderId, reason, amount):
+$refund = LaravelPolar::createRefund(new Components\RefundCreate(
+    orderId: 'ord_xxx',
+    reason: Components\RefundReason::Duplicate,
+    amount: 1000,
+));
+
+// List refunds with optional filters:
+$response = LaravelPolar::listRefunds(); // Operations\RefundsListResponse
+$response = LaravelPolar::listRefunds(new Operations\RefundsListRequest(
+    orderId: 'ord_xxx',
+));
+```
+
+## Required user actions
+
+None. Pure addition — `composer update danestves/laravel-polar` and the new methods are available.
+
+## Notes
+
+- `$order->refund()` defaults `amount` to the remaining unrefunded portion (`$order->amount - $order->refunded_amount`) and `reason` to `RefundReason::CustomerRequest`.
+- `$order->refund()` throws `\RuntimeException` if the order has no `polar_id` set (i.e. the order has not yet been synced from Polar).
+- `$order->refunds()` returns an empty `Collection` if `polar_id` is null (defensive — no Polar call is made).
+- Both `createRefund` and `listRefunds` re-throw `Polar\Models\Errors\APIException` on non-success status codes, consistent with the rest of the package.

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.3.0';
+    public const string VERSION = '2.4.0';
 
     /**
      * The cached Polar SDK instance.
@@ -296,6 +296,50 @@ class LaravelPolar
         }
 
         throw new Errors\APIException('Failed to get customer meter', 500, '', null);
+    }
+
+    /**
+     * Create a refund for an order.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function createRefund(Components\RefundCreate $request): Components\Refund
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->refunds->create(request: $request);
+
+        if ($response->statusCode === 200 && $response->refund !== null) {
+            return $response->refund;
+        }
+
+        throw new Errors\APIException('Failed to create refund', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * List refunds.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function listRefunds(?Operations\RefundsListRequest $request = null): Operations\RefundsListResponse
+    {
+        $sdk = self::sdk();
+
+        if ($request === null) {
+            $request = new Operations\RefundsListRequest();
+        }
+
+        $generator = $sdk->refunds->list(request: $request);
+
+        foreach ($generator as $response) {
+            if ($response->statusCode === 200) {
+                return $response;
+            }
+        }
+
+        throw new Errors\APIException('Failed to list refunds', 500, '', null);
     }
 
     /**

--- a/src/Order.php
+++ b/src/Order.php
@@ -77,6 +77,57 @@ class Order extends Model // @phpstan-ignore-line propertyTag.trait - Billable i
     }
 
     /**
+     * Issue a refund for this order. Defaults to refunding the remaining
+     * unrefunded amount with reason "customer_request".
+     *
+     * @param  array<string, scalar|null>|null  $metadata
+     *
+     * @throws \Polar\Models\Errors\APIException
+     * @throws \Exception
+     */
+    public function refund(
+        ?int $amount = null,
+        ?\Polar\Models\Components\RefundReason $reason = null,
+        ?string $comment = null,
+        ?array $metadata = null,
+    ): \Polar\Models\Components\Refund {
+        if ($this->polar_id === null) {
+            throw new \RuntimeException('Order has no polar_id; cannot refund.');
+        }
+
+        $request = new \Polar\Models\Components\RefundCreate(
+            orderId: $this->polar_id,
+            reason: $reason ?? \Polar\Models\Components\RefundReason::CustomerRequest,
+            amount: $amount ?? max(0, $this->amount - $this->refunded_amount),
+            metadata: $metadata,
+            comment: $comment,
+        );
+
+        return LaravelPolar::createRefund($request);
+    }
+
+    /**
+     * List refunds for this order.
+     *
+     * @return \Illuminate\Support\Collection<int, \Polar\Models\Components\Refund>
+     *
+     * @throws \Polar\Models\Errors\APIException
+     * @throws \Exception
+     */
+    public function refunds(): \Illuminate\Support\Collection
+    {
+        if ($this->polar_id === null) {
+            return collect();
+        }
+
+        $response = LaravelPolar::listRefunds(
+            new \Polar\Models\Operations\RefundsListRequest(orderId: $this->polar_id),
+        );
+
+        return collect($response->listResourceRefund->items ?? []);
+    }
+
+    /**
      * Check if the order is refunded.
      */
     public function refunded(): bool

--- a/tests/Feature/RefundsTest.php
+++ b/tests/Feature/RefundsTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\LaravelPolar;
+use Danestves\LaravelPolar\Order;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function createMockedSdkWithRefunds(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $refunds = Mockery::mock(\Polar\Refunds::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $refundsProperty = $reflectionSdk->getProperty('refunds');
+    $refundsProperty->setAccessible(true);
+    $refundsProperty->setValue($sdk, $refunds);
+
+    return ['sdk' => $sdk, 'refunds' => $refunds];
+}
+
+it('forwards createRefund to the SDK and returns the refund on success', function () {
+    $mocked = createMockedSdkWithRefunds();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $refundMock = Mockery::mock(Components\Refund::class);
+    $response = new Operations\RefundsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        refund: $refundMock,
+    );
+
+    $request = new Components\RefundCreate(
+        orderId: 'ord_123',
+        reason: Components\RefundReason::CustomerRequest,
+        amount: 5000,
+    );
+
+    $mocked['refunds']->shouldReceive('create')
+        ->once()
+        ->withArgs(function ($body) {
+            return $body instanceof Components\RefundCreate
+                && $body->orderId === 'ord_123'
+                && $body->reason === Components\RefundReason::CustomerRequest
+                && $body->amount === 5000;
+        })
+        ->andReturn($response);
+
+    $result = LaravelPolar::createRefund($request);
+
+    expect($result)->toBe($refundMock);
+});
+
+it('throws when createRefund SDK call returns a non-200 status', function () {
+    $mocked = createMockedSdkWithRefunds();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\RefundsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        refund: null,
+    );
+
+    $mocked['refunds']->shouldReceive('create')->andReturn($response);
+
+    $request = new Components\RefundCreate(
+        orderId: 'ord_123',
+        reason: Components\RefundReason::Other,
+        amount: 100,
+    );
+
+    expect(fn() => LaravelPolar::createRefund($request))
+        ->toThrow(\Polar\Models\Errors\APIException::class);
+});
+
+it('listRefunds returns the first 200 response from the paginated generator', function () {
+    $mocked = createMockedSdkWithRefunds();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $list = new Components\ListResourceRefund(
+        items: [Mockery::mock(Components\Refund::class)],
+        pagination: new Components\Pagination(totalCount: 1, maxPage: 1),
+    );
+
+    $response = new Operations\RefundsListResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        listResourceRefund: $list,
+    );
+
+    $mocked['refunds']->shouldReceive('list')->andReturn((function () use ($response) {
+        yield $response;
+    })());
+
+    $result = LaravelPolar::listRefunds();
+
+    expect($result)->toBe($response);
+    expect($result->listResourceRefund?->items)->toHaveCount(1);
+});
+
+it('Order::refund forwards to LaravelPolar::createRefund with defaults filled from the order', function () {
+    $mocked = createMockedSdkWithRefunds();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $order = Order::factory()->paid()->create([
+        'polar_id' => 'ord_abc',
+        'amount' => 10000,
+        'refunded_amount' => 3000,
+    ]);
+
+    $refundMock = Mockery::mock(Components\Refund::class);
+    $response = new Operations\RefundsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        refund: $refundMock,
+    );
+
+    $mocked['refunds']->shouldReceive('create')
+        ->once()
+        ->withArgs(function ($body) {
+            return $body instanceof Components\RefundCreate
+                && $body->orderId === 'ord_abc'
+                && $body->reason === Components\RefundReason::CustomerRequest
+                && $body->amount === 7000;
+        })
+        ->andReturn($response);
+
+    $result = $order->refund();
+
+    expect($result)->toBe($refundMock);
+});
+
+it('Order::refund honors a provided amount, reason, comment, and metadata', function () {
+    $mocked = createMockedSdkWithRefunds();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $order = Order::factory()->paid()->create([
+        'polar_id' => 'ord_def',
+        'amount' => 10000,
+        'refunded_amount' => 0,
+    ]);
+
+    $refundMock = Mockery::mock(Components\Refund::class);
+    $response = new Operations\RefundsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        refund: $refundMock,
+    );
+
+    $mocked['refunds']->shouldReceive('create')
+        ->once()
+        ->withArgs(function ($body) {
+            return $body instanceof Components\RefundCreate
+                && $body->orderId === 'ord_def'
+                && $body->amount === 2500
+                && $body->reason === Components\RefundReason::Fraudulent
+                && $body->comment === 'flagged by risk team'
+                && $body->metadata === ['ticket' => 'T-42'];
+        })
+        ->andReturn($response);
+
+    $order->refund(
+        amount: 2500,
+        reason: Components\RefundReason::Fraudulent,
+        comment: 'flagged by risk team',
+        metadata: ['ticket' => 'T-42'],
+    );
+});
+
+it('Order::refunds returns a Collection of Refund items for this order', function () {
+    $mocked = createMockedSdkWithRefunds();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $order = Order::factory()->paid()->create([
+        'polar_id' => 'ord_ghi',
+    ]);
+
+    $refund1 = Mockery::mock(Components\Refund::class);
+    $refund2 = Mockery::mock(Components\Refund::class);
+
+    $list = new Components\ListResourceRefund(
+        items: [$refund1, $refund2],
+        pagination: new Components\Pagination(totalCount: 2, maxPage: 1),
+    );
+
+    $response = new Operations\RefundsListResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        listResourceRefund: $list,
+    );
+
+    $mocked['refunds']->shouldReceive('list')
+        ->once()
+        ->withArgs(function ($request) {
+            return $request instanceof Operations\RefundsListRequest
+                && $request->orderId === 'ord_ghi';
+        })
+        ->andReturn((function () use ($response) {
+            yield $response;
+        })());
+
+    $refunds = $order->refunds();
+
+    expect($refunds)->toHaveCount(2);
+    expect($refunds->first())->toBe($refund1);
+});
+
+it('Order::refunds returns an empty collection when the order has no polar_id', function () {
+    $order = Order::factory()->paid()->create(['polar_id' => null]);
+
+    expect($order->refunds())->toHaveCount(0);
+});
+
+it('Order::refund throws when the order has no polar_id', function () {
+    $order = Order::factory()->paid()->create(['polar_id' => null]);
+
+    expect(fn() => $order->refund(amount: 100))
+        ->toThrow(\RuntimeException::class, 'Order has no polar_id');
+});


### PR DESCRIPTION
## Summary

Adds the ability to issue and list refunds directly from an \`Order\` model and via the \`LaravelPolar\` facade.

Purely additive — no breaking changes.

\`\`\`php
use Polar\Models\Components\RefundReason;

// Full refund of remaining unrefunded amount:
\$order->refund();

// Partial refund with reason:
\$order->refund(amount: 2500, reason: RefundReason::Fraudulent);

// List refunds for this order:
\$order->refunds(); // Illuminate\Support\Collection<int, Refund>

// Admin-level (use any orderId):
LaravelPolar::createRefund(new Components\RefundCreate(...));
LaravelPolar::listRefunds(new Operations\RefundsListRequest(...));
\`\`\`

## What's in this PR

- \`LaravelPolar::createRefund\` and \`LaravelPolar::listRefunds\` facade methods.
- \`\$order->refund()\` and \`\$order->refunds()\` methods on \`src/Order.php\`. \`refund()\` defaults \`amount\` to \`(\$this->amount - \$this->refunded_amount)\` and \`reason\` to \`CustomerRequest\`.
- 8 new Pest tests covering: happy path, error path on non-200, list response handling, defaults applied from the order, custom arguments respected, empty collection when polar_id is null, exception when refunding an unsynced order.
- VERSION constant bumped to \`2.4.0\`.
- \`docs/migration-v2.3-to-v2.4.md\` (purely additive — no user action required).

## Test plan

- [x] \`vendor/bin/pest\` — 129 tests pass (321 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.4.0\` on merge per the v2.x release flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refund functionality to orders, supporting full, partial, and customized refunds with configurable reasons and metadata.
  * Added admin-level facade methods for creating and listing refunds.

* **Documentation**
  * Added migration guide for upgrading from v2.3 to v2.4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danestves/laravel-polar/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->