### PR TITLE
feat(discounts): admin CRUD via LaravelPolar facade

### DIFF
--- a/docs/migration-v2.4-to-v2.5.md
+++ b/docs/migration-v2.4-to-v2.5.md
@@ -1,0 +1,49 @@
+# Migrating from v2.4 to v2.5
+
+`v2.5.0` is **purely additive** — your existing code continues to work without changes.
+
+## What's new
+
+Five new admin facade methods on `LaravelPolar` for managing discount codes. The customer-side application of a discount (`Checkout::withDiscountId()` and `Checkout::withoutDiscountCodes()`) already shipped in v2.0 and is unchanged.
+
+```php
+use Danestves\LaravelPolar\LaravelPolar;
+use Polar\Models\Components;
+use Polar\Models\Operations;
+
+// Create a discount:
+$discount = LaravelPolar::createDiscount(new Components\DiscountPercentageOnceForeverDurationCreate(
+    name: 'Black Friday 50%',
+    type: Components\DiscountType::Percentage,
+    duration: Components\DiscountDuration::Once,
+    basisPoints: 5000,
+    organizationId: 'org_xxx',
+));
+
+// Update a discount:
+$discount = LaravelPolar::updateDiscount('disc_xxx', new Components\DiscountUpdate(
+    name: 'Black Friday Extended',
+));
+
+// Delete a discount:
+LaravelPolar::deleteDiscount('disc_xxx');
+
+// List discounts:
+$response = LaravelPolar::listDiscounts(); // Operations\DiscountsListResponse
+$items = $response->listResourceDiscount?->items ?? [];
+
+// Get a single discount:
+$discount = LaravelPolar::getDiscount('disc_xxx');
+```
+
+The four create variants supported by the SDK are `DiscountFixedOnceForeverDurationCreate`, `DiscountFixedRepeatDurationCreate`, `DiscountPercentageOnceForeverDurationCreate`, and `DiscountPercentageRepeatDurationCreate`. The returned discount type is the corresponding non-`Create` variant.
+
+## Required user actions
+
+None. Pure addition — `composer update danestves/laravel-polar` and the new methods are available.
+
+## Notes
+
+- All five methods re-throw `Polar\Models\Errors\APIException` on non-success status codes, consistent with the rest of the package.
+- `LaravelPolar::createDiscount` expects a `201 Created` from the Polar API.
+- `LaravelPolar::deleteDiscount` accepts either `200 OK` or `204 No Content` from the Polar API.

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.4.0';
+    public const string VERSION = '2.5.0';
 
     /**
      * The cached Polar SDK instance.
@@ -296,6 +296,105 @@ class LaravelPolar
         }
 
         throw new Errors\APIException('Failed to get customer meter', 500, '', null);
+    }
+
+    /**
+     * Create a discount.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function createDiscount(Components\DiscountFixedOnceForeverDurationCreate|Components\DiscountFixedRepeatDurationCreate|Components\DiscountPercentageOnceForeverDurationCreate|Components\DiscountPercentageRepeatDurationCreate $request): Components\DiscountFixedOnceForeverDuration|Components\DiscountFixedRepeatDuration|Components\DiscountPercentageOnceForeverDuration|Components\DiscountPercentageRepeatDuration
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->discounts->create(request: $request);
+
+        if ($response->statusCode === 201 && $response->discount !== null) {
+            return $response->discount;
+        }
+
+        throw new Errors\APIException('Failed to create discount', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Update a discount.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function updateDiscount(string $discountId, Components\DiscountUpdate $request): Components\DiscountFixedOnceForeverDuration|Components\DiscountFixedRepeatDuration|Components\DiscountPercentageOnceForeverDuration|Components\DiscountPercentageRepeatDuration
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->discounts->update(discountUpdate: $request, id: $discountId);
+
+        if ($response->statusCode === 200 && $response->discount !== null) {
+            return $response->discount;
+        }
+
+        throw new Errors\APIException('Failed to update discount', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Delete a discount.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function deleteDiscount(string $discountId): void
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->discounts->delete(id: $discountId);
+
+        if ($response->statusCode !== 200 && $response->statusCode !== 204) {
+            throw new Errors\APIException('Failed to delete discount', $response->statusCode, '', null);
+        }
+    }
+
+    /**
+     * List discounts.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function listDiscounts(?Operations\DiscountsListRequest $request = null): Operations\DiscountsListResponse
+    {
+        $sdk = self::sdk();
+
+        if ($request === null) {
+            $request = new Operations\DiscountsListRequest();
+        }
+
+        $generator = $sdk->discounts->list(request: $request);
+
+        foreach ($generator as $response) {
+            if ($response->statusCode === 200) {
+                return $response;
+            }
+        }
+
+        throw new Errors\APIException('Failed to list discounts', 500, '', null);
+    }
+
+    /**
+     * Get a specific discount by ID.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function getDiscount(string $discountId): Components\DiscountFixedOnceForeverDuration|Components\DiscountFixedRepeatDuration|Components\DiscountPercentageOnceForeverDuration|Components\DiscountPercentageRepeatDuration
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->discounts->get(id: $discountId);
+
+        if ($response->statusCode === 200 && $response->discount !== null) {
+            return $response->discount;
+        }
+
+        throw new Errors\APIException('Failed to get discount', $response->statusCode ?? 500, '', null);
     }
 
     /**

--- a/tests/Feature/DiscountsTest.php
+++ b/tests/Feature/DiscountsTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\LaravelPolar;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Errors;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function createMockedSdkWithDiscounts(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $discounts = Mockery::mock(\Polar\Discounts::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $discountsProperty = $reflectionSdk->getProperty('discounts');
+    $discountsProperty->setAccessible(true);
+    $discountsProperty->setValue($sdk, $discounts);
+
+    return ['sdk' => $sdk, 'discounts' => $discounts];
+}
+
+it('createDiscount forwards to SDK and returns the discount on 201', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $discountMock = Mockery::mock(Components\DiscountPercentageOnceForeverDuration::class);
+    $response = new Operations\DiscountsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 201,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        discount: $discountMock,
+    );
+
+    $mocked['discounts']->shouldReceive('create')->once()->andReturn($response);
+
+    $request = new Components\DiscountPercentageOnceForeverDurationCreate(
+        name: '50% Off',
+        type: Components\DiscountType::Percentage,
+        duration: Components\DiscountDuration::Once,
+        basisPoints: 5000,
+        organizationId: 'org_123',
+    );
+
+    expect(LaravelPolar::createDiscount($request))->toBe($discountMock);
+});
+
+it('createDiscount throws when SDK returns non-201', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\DiscountsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        discount: null,
+    );
+
+    $mocked['discounts']->shouldReceive('create')->andReturn($response);
+
+    $request = new Components\DiscountPercentageOnceForeverDurationCreate(
+        name: 'X',
+        type: Components\DiscountType::Percentage,
+        duration: Components\DiscountDuration::Once,
+        basisPoints: 100,
+        organizationId: 'org_123',
+    );
+
+    expect(fn() => LaravelPolar::createDiscount($request))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('updateDiscount forwards to SDK with the right id and returns updated discount on 200', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $discountMock = Mockery::mock(Components\DiscountPercentageOnceForeverDuration::class);
+    $response = new Operations\DiscountsUpdateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        discount: $discountMock,
+    );
+
+    $mocked['discounts']->shouldReceive('update')
+        ->once()
+        ->withArgs(function ($body, string $id) {
+            return $id === 'disc_xyz' && $body instanceof Components\DiscountUpdate;
+        })
+        ->andReturn($response);
+
+    $request = new Components\DiscountUpdate(name: 'Updated name');
+
+    expect(LaravelPolar::updateDiscount('disc_xyz', $request))->toBe($discountMock);
+});
+
+it('deleteDiscount accepts a 200 or 204 response and throws otherwise', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $okResponse = new Operations\DiscountsDeleteResponse(
+        contentType: 'application/json',
+        statusCode: 204,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['discounts']->shouldReceive('delete')->once()->andReturn($okResponse);
+
+    LaravelPolar::deleteDiscount('disc_ok');
+
+    $errResponse = new Operations\DiscountsDeleteResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['discounts']->shouldReceive('delete')->once()->andReturn($errResponse);
+
+    expect(fn() => LaravelPolar::deleteDiscount('disc_bad'))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('listDiscounts returns the first 200 page from the generator', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $list = new Components\ListResourceDiscount(
+        items: [Mockery::mock(Components\DiscountPercentageOnceForeverDuration::class)],
+        pagination: new Components\Pagination(totalCount: 1, maxPage: 1),
+    );
+
+    $response = new Operations\DiscountsListResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        listResourceDiscount: $list,
+    );
+
+    $mocked['discounts']->shouldReceive('list')->andReturn((function () use ($response) {
+        yield $response;
+    })());
+
+    $result = LaravelPolar::listDiscounts();
+
+    expect($result)->toBe($response);
+    expect($result->listResourceDiscount?->items)->toHaveCount(1);
+});
+
+it('getDiscount returns the discount on 200', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $discountMock = Mockery::mock(Components\DiscountPercentageOnceForeverDuration::class);
+    $response = new Operations\DiscountsGetResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        discount: $discountMock,
+    );
+
+    $mocked['discounts']->shouldReceive('get')
+        ->once()
+        ->with('disc_abc')
+        ->andReturn($response);
+
+    expect(LaravelPolar::getDiscount('disc_abc'))->toBe($discountMock);
+});
+
+it('getDiscount throws when the SDK returns non-200', function () {
+    $mocked = createMockedSdkWithDiscounts();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\DiscountsGetResponse(
+        contentType: 'application/json',
+        statusCode: 404,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        discount: null,
+    );
+
+    $mocked['discounts']->shouldReceive('get')->andReturn($response);
+
+    expect(fn() => LaravelPolar::getDiscount('disc_missing'))
+        ->toThrow(Errors\APIException::class);
+});


### PR DESCRIPTION
## Summary

Adds the admin management surface for Polar discounts via the \`LaravelPolar\` facade. The customer-side application (\`Checkout::withDiscountId()\` and \`Checkout::withoutDiscountCodes()\`) already shipped in v2.0 and is unchanged.

Purely additive — no breaking changes.

\`\`\`php
use Danestves\LaravelPolar\LaravelPolar;
use Polar\Models\Components;

LaravelPolar::createDiscount(new Components\DiscountPercentageOnceForeverDurationCreate(...));
LaravelPolar::updateDiscount('disc_xxx', new Components\DiscountUpdate(name: 'New name'));
LaravelPolar::deleteDiscount('disc_xxx');
LaravelPolar::listDiscounts();
LaravelPolar::getDiscount('disc_xxx');
\`\`\`

## What's in this PR

- Five new static facade methods on \`src/LaravelPolar.php\` matching the existing \`createBenefit\` / \`updateBenefit\` etc. style.
- 7 new Pest tests covering happy paths and error paths (non-201/200 throws, 204 accepted on delete).
- VERSION constant bumped to \`2.5.0\`.
- \`docs/migration-v2.4-to-v2.5.md\` (purely additive — no user action required).

## Test plan

- [x] \`vendor/bin/pest\` — 136 tests pass (334 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.5.0\` on merge per the v2.x release flow.