### PR TITLE
feat(checkout-links): admin CRUD via LaravelPolar facade

### DIFF
--- a/docs/migration-v2.5-to-v2.6.md
+++ b/docs/migration-v2.5-to-v2.6.md
@@ -1,0 +1,51 @@
+# Migrating from v2.5 to v2.6
+
+`v2.6.0` is **purely additive** — your existing code continues to work without changes.
+
+## What's new
+
+Five new admin facade methods on `LaravelPolar` for managing checkout links.
+
+```php
+use Danestves\LaravelPolar\LaravelPolar;
+use Polar\Models\Components;
+use Polar\Models\Operations;
+
+// Create a checkout link (three variants supported by the SDK):
+$link = LaravelPolar::createCheckoutLink(new Components\CheckoutLinkCreateProduct(
+    productId: 'prod_xxx',
+    paymentProcessor: 'stripe',
+));
+
+// Or for multiple products / specific price:
+LaravelPolar::createCheckoutLink(new Components\CheckoutLinkCreateProducts(...));
+LaravelPolar::createCheckoutLink(new Components\CheckoutLinkCreateProductPrice(...));
+
+// Update a checkout link:
+LaravelPolar::updateCheckoutLink('cl_xxx', new Components\CheckoutLinkUpdate(
+    label: 'Updated label',
+));
+
+// Delete a checkout link:
+LaravelPolar::deleteCheckoutLink('cl_xxx');
+
+// List checkout links:
+$response = LaravelPolar::listCheckoutLinks(); // Operations\CheckoutLinksListResponse
+$items = $response->listResourceCheckoutLink?->items ?? [];
+
+// Get a single checkout link:
+$link = LaravelPolar::getCheckoutLink('cl_xxx');
+
+// Use the link's URL in your views:
+echo $link->url;
+```
+
+## Required user actions
+
+None. Pure addition — `composer update danestves/laravel-polar` and the new methods are available.
+
+## Notes
+
+- All five methods re-throw `Polar\Models\Errors\APIException` on non-success status codes.
+- `LaravelPolar::createCheckoutLink` expects a `201 Created` from the Polar API.
+- `LaravelPolar::deleteCheckoutLink` accepts either `200 OK` or `204 No Content`.

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.5.0';
+    public const string VERSION = '2.6.0';
 
     /**
      * The cached Polar SDK instance.
@@ -296,6 +296,105 @@ class LaravelPolar
         }
 
         throw new Errors\APIException('Failed to get customer meter', 500, '', null);
+    }
+
+    /**
+     * Create a checkout link.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function createCheckoutLink(Components\CheckoutLinkCreateProductPrice|Components\CheckoutLinkCreateProduct|Components\CheckoutLinkCreateProducts $request): Components\CheckoutLink
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->checkoutLinks->create(request: $request);
+
+        if ($response->statusCode === 201 && $response->checkoutLink !== null) {
+            return $response->checkoutLink;
+        }
+
+        throw new Errors\APIException('Failed to create checkout link', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Update a checkout link.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function updateCheckoutLink(string $checkoutLinkId, Components\CheckoutLinkUpdate $request): Components\CheckoutLink
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->checkoutLinks->update(checkoutLinkUpdate: $request, id: $checkoutLinkId);
+
+        if ($response->statusCode === 200 && $response->checkoutLink !== null) {
+            return $response->checkoutLink;
+        }
+
+        throw new Errors\APIException('Failed to update checkout link', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Delete a checkout link.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function deleteCheckoutLink(string $checkoutLinkId): void
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->checkoutLinks->delete(id: $checkoutLinkId);
+
+        if ($response->statusCode !== 200 && $response->statusCode !== 204) {
+            throw new Errors\APIException('Failed to delete checkout link', $response->statusCode, '', null);
+        }
+    }
+
+    /**
+     * List checkout links.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function listCheckoutLinks(?Operations\CheckoutLinksListRequest $request = null): Operations\CheckoutLinksListResponse
+    {
+        $sdk = self::sdk();
+
+        if ($request === null) {
+            $request = new Operations\CheckoutLinksListRequest();
+        }
+
+        $generator = $sdk->checkoutLinks->list(request: $request);
+
+        foreach ($generator as $response) {
+            if ($response->statusCode === 200) {
+                return $response;
+            }
+        }
+
+        throw new Errors\APIException('Failed to list checkout links', 500, '', null);
+    }
+
+    /**
+     * Get a specific checkout link by ID.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function getCheckoutLink(string $checkoutLinkId): Components\CheckoutLink
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->checkoutLinks->get(id: $checkoutLinkId);
+
+        if ($response->statusCode === 200 && $response->checkoutLink !== null) {
+            return $response->checkoutLink;
+        }
+
+        throw new Errors\APIException('Failed to get checkout link', $response->statusCode ?? 500, '', null);
     }
 
     /**

--- a/tests/Feature/CheckoutLinksTest.php
+++ b/tests/Feature/CheckoutLinksTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\LaravelPolar;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Errors;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function createMockedSdkWithCheckoutLinks(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $checkoutLinks = Mockery::mock(\Polar\CheckoutLinks::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $checkoutLinksProperty = $reflectionSdk->getProperty('checkoutLinks');
+    $checkoutLinksProperty->setAccessible(true);
+    $checkoutLinksProperty->setValue($sdk, $checkoutLinks);
+
+    return ['sdk' => $sdk, 'checkoutLinks' => $checkoutLinks];
+}
+
+it('createCheckoutLink forwards to SDK and returns link on 201', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $linkMock = Mockery::mock(Components\CheckoutLink::class);
+    $response = new Operations\CheckoutLinksCreateResponse(
+        contentType: 'application/json',
+        statusCode: 201,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        checkoutLink: $linkMock,
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('create')->once()->andReturn($response);
+
+    $request = new Components\CheckoutLinkCreateProduct(
+        productId: 'prod_xxx',
+        paymentProcessor: 'stripe',
+    );
+
+    expect(LaravelPolar::createCheckoutLink($request))->toBe($linkMock);
+});
+
+it('createCheckoutLink throws on non-201', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\CheckoutLinksCreateResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        checkoutLink: null,
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('create')->andReturn($response);
+
+    $request = new Components\CheckoutLinkCreateProduct(
+        productId: 'prod_xxx',
+        paymentProcessor: 'stripe',
+    );
+
+    expect(fn() => LaravelPolar::createCheckoutLink($request))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('updateCheckoutLink forwards to SDK and returns updated link on 200', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $linkMock = Mockery::mock(Components\CheckoutLink::class);
+    $response = new Operations\CheckoutLinksUpdateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        checkoutLink: $linkMock,
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('update')
+        ->once()
+        ->withArgs(fn($body, string $id) => $id === 'cl_xyz' && $body instanceof Components\CheckoutLinkUpdate)
+        ->andReturn($response);
+
+    $request = new Components\CheckoutLinkUpdate(label: 'Updated label');
+
+    expect(LaravelPolar::updateCheckoutLink('cl_xyz', $request))->toBe($linkMock);
+});
+
+it('deleteCheckoutLink accepts 200 or 204 and throws otherwise', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $ok = new Operations\CheckoutLinksDeleteResponse(
+        contentType: 'application/json',
+        statusCode: 204,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('delete')->once()->andReturn($ok);
+    LaravelPolar::deleteCheckoutLink('cl_ok');
+
+    $err = new Operations\CheckoutLinksDeleteResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('delete')->once()->andReturn($err);
+    expect(fn() => LaravelPolar::deleteCheckoutLink('cl_bad'))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('listCheckoutLinks returns the first 200 page from the generator', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $list = new Components\ListResourceCheckoutLink(
+        items: [Mockery::mock(Components\CheckoutLink::class)],
+        pagination: new Components\Pagination(totalCount: 1, maxPage: 1),
+    );
+
+    $response = new Operations\CheckoutLinksListResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        listResourceCheckoutLink: $list,
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('list')->andReturn((function () use ($response) {
+        yield $response;
+    })());
+
+    $result = LaravelPolar::listCheckoutLinks();
+
+    expect($result)->toBe($response);
+    expect($result->listResourceCheckoutLink?->items)->toHaveCount(1);
+});
+
+it('getCheckoutLink returns the link on 200', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $linkMock = Mockery::mock(Components\CheckoutLink::class);
+    $response = new Operations\CheckoutLinksGetResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        checkoutLink: $linkMock,
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('get')
+        ->once()
+        ->with('cl_abc')
+        ->andReturn($response);
+
+    expect(LaravelPolar::getCheckoutLink('cl_abc'))->toBe($linkMock);
+});
+
+it('getCheckoutLink throws when SDK returns non-200', function () {
+    $mocked = createMockedSdkWithCheckoutLinks();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\CheckoutLinksGetResponse(
+        contentType: 'application/json',
+        statusCode: 404,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        checkoutLink: null,
+    );
+
+    $mocked['checkoutLinks']->shouldReceive('get')->andReturn($response);
+
+    expect(fn() => LaravelPolar::getCheckoutLink('cl_missing'))
+        ->toThrow(Errors\APIException::class);
+});


### PR DESCRIPTION
## Summary

Adds the admin management surface for Polar checkout links via the \`LaravelPolar\` facade.

Purely additive — no breaking changes.

\`\`\`php
use Danestves\LaravelPolar\LaravelPolar;
use Polar\Models\Components;

LaravelPolar::createCheckoutLink(new Components\CheckoutLinkCreateProduct(
    productId: 'prod_xxx',
    paymentProcessor: 'stripe',
));
LaravelPolar::updateCheckoutLink('cl_xxx', new Components\CheckoutLinkUpdate(label: 'New label'));
LaravelPolar::deleteCheckoutLink('cl_xxx');
LaravelPolar::listCheckoutLinks();
LaravelPolar::getCheckoutLink('cl_xxx');
\`\`\`

## What's in this PR

- Five new static facade methods on \`src/LaravelPolar.php\` matching the existing CRUD style.
- 7 new Pest tests covering happy paths and error paths (non-201/200 throws, 204 accepted on delete).
- VERSION constant bumped to \`2.6.0\`.
- \`docs/migration-v2.5-to-v2.6.md\` (purely additive — no user action required).

## Test plan

- [x] \`vendor/bin/pest\` — 143 tests pass (347 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.6.0\` on merge per the v2.x release flow.