### PR TITLE
feat(custom-fields): admin CRUD + Order::customFieldData accessor

### DIFF
--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.6.0';
+    public const string VERSION = '2.7.0';
 
     /**
      * The cached Polar SDK instance.
@@ -296,6 +296,105 @@ class LaravelPolar
         }
 
         throw new Errors\APIException('Failed to get customer meter', 500, '', null);
+    }
+
+    /**
+     * Create a custom field.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function createCustomField(Components\CustomFieldCreateText|Components\CustomFieldCreateNumber|Components\CustomFieldCreateDate|Components\CustomFieldCreateCheckbox|Components\CustomFieldCreateSelect $request): Components\CustomFieldText|Components\CustomFieldNumber|Components\CustomFieldDate|Components\CustomFieldCheckbox|Components\CustomFieldSelect
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customFields->create(request: $request);
+
+        if ($response->statusCode === 201 && $response->customField !== null) {
+            return $response->customField;
+        }
+
+        throw new Errors\APIException('Failed to create custom field', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Update a custom field.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function updateCustomField(string $customFieldId, Components\CustomFieldUpdateText|Components\CustomFieldUpdateNumber|Components\CustomFieldUpdateDate|Components\CustomFieldUpdateCheckbox|Components\CustomFieldUpdateSelect $request): Components\CustomFieldText|Components\CustomFieldNumber|Components\CustomFieldDate|Components\CustomFieldCheckbox|Components\CustomFieldSelect
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customFields->update(customFieldUpdate: $request, id: $customFieldId);
+
+        if ($response->statusCode === 200 && $response->customField !== null) {
+            return $response->customField;
+        }
+
+        throw new Errors\APIException('Failed to update custom field', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Delete a custom field.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function deleteCustomField(string $customFieldId): void
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customFields->delete(id: $customFieldId);
+
+        if ($response->statusCode !== 200 && $response->statusCode !== 204) {
+            throw new Errors\APIException('Failed to delete custom field', $response->statusCode, '', null);
+        }
+    }
+
+    /**
+     * List custom fields.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function listCustomFields(?Operations\CustomFieldsListRequest $request = null): Operations\CustomFieldsListResponse
+    {
+        $sdk = self::sdk();
+
+        if ($request === null) {
+            $request = new Operations\CustomFieldsListRequest();
+        }
+
+        $generator = $sdk->customFields->list(request: $request);
+
+        foreach ($generator as $response) {
+            if ($response->statusCode === 200) {
+                return $response;
+            }
+        }
+
+        throw new Errors\APIException('Failed to list custom fields', 500, '', null);
+    }
+
+    /**
+     * Get a specific custom field by ID.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function getCustomField(string $customFieldId): Components\CustomFieldText|Components\CustomFieldNumber|Components\CustomFieldDate|Components\CustomFieldCheckbox|Components\CustomFieldSelect
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customFields->get(id: $customFieldId);
+
+        if ($response->statusCode === 200 && $response->customField !== null) {
+            return $response->customField;
+        }
+
+        throw new Errors\APIException('Failed to get custom field', $response->statusCode ?? 500, '', null);
     }
 
     /**

--- a/src/Order.php
+++ b/src/Order.php
@@ -77,6 +77,45 @@ class Order extends Model // @phpstan-ignore-line propertyTag.trait - Billable i
     }
 
     /**
+     * Cached custom-field data fetched from Polar.
+     *
+     * @var array<string, string|int|bool|\DateTime|null>|null
+     */
+    protected ?array $cachedCustomFieldData = null;
+
+    /**
+     * Fetch the custom-field data captured at checkout for this order.
+     *
+     * Data is not persisted in `polar_orders`; this method fetches the order
+     * from Polar on demand and memoizes the result for the lifetime of this
+     * Order instance.
+     *
+     * @return array<string, string|int|bool|\DateTime|null>
+     *
+     * @throws \Polar\Models\Errors\APIException
+     * @throws \Exception
+     */
+    public function customFieldData(): array
+    {
+        if ($this->cachedCustomFieldData !== null) {
+            return $this->cachedCustomFieldData;
+        }
+
+        if ($this->polar_id === null) {
+            return $this->cachedCustomFieldData = [];
+        }
+
+        $sdkResponse = LaravelPolar::sdk()->orders->get(id: $this->polar_id);
+        $sdkOrder = $sdkResponse->order;
+
+        if ($sdkOrder === null) {
+            return $this->cachedCustomFieldData = [];
+        }
+
+        return $this->cachedCustomFieldData = $sdkOrder->customFieldData ?? [];
+    }
+
+    /**
      * Issue a refund for this order. Defaults to refunding the remaining
      * unrefunded amount with reason "customer_request".
      *

--- a/tests/Feature/CustomFieldsTest.php
+++ b/tests/Feature/CustomFieldsTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\LaravelPolar;
+use Danestves\LaravelPolar\Order;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Errors;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function createMockedSdkWithCustomFields(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $customFields = Mockery::mock(\Polar\CustomFields::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $customFieldsProperty = $reflectionSdk->getProperty('customFields');
+    $customFieldsProperty->setAccessible(true);
+    $customFieldsProperty->setValue($sdk, $customFields);
+
+    return ['sdk' => $sdk, 'customFields' => $customFields];
+}
+
+function createMockedSdkWithOrders(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $orders = Mockery::mock(\Polar\Orders::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $ordersProperty = $reflectionSdk->getProperty('orders');
+    $ordersProperty->setAccessible(true);
+    $ordersProperty->setValue($sdk, $orders);
+
+    return ['sdk' => $sdk, 'orders' => $orders];
+}
+
+it('createCustomField forwards to SDK and returns the custom field on 201', function () {
+    $mocked = createMockedSdkWithCustomFields();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $cfMock = Mockery::mock(Components\CustomFieldText::class);
+    $response = new Operations\CustomFieldsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 201,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customField: $cfMock,
+    );
+
+    $mocked['customFields']->shouldReceive('create')->once()->andReturn($response);
+
+    $request = new Components\CustomFieldCreateText(
+        slug: 'company',
+        name: 'Company name',
+        properties: new Components\CustomFieldTextProperties(),
+    );
+
+    expect(LaravelPolar::createCustomField($request))->toBe($cfMock);
+});
+
+it('updateCustomField forwards to SDK and returns the updated custom field on 200', function () {
+    $mocked = createMockedSdkWithCustomFields();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $cfMock = Mockery::mock(Components\CustomFieldText::class);
+    $response = new Operations\CustomFieldsUpdateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customField: $cfMock,
+    );
+
+    $mocked['customFields']->shouldReceive('update')
+        ->once()
+        ->withArgs(fn($body, string $id) => $id === 'cf_xyz' && $body instanceof Components\CustomFieldUpdateText)
+        ->andReturn($response);
+
+    $request = new Components\CustomFieldUpdateText(name: 'Updated label');
+
+    expect(LaravelPolar::updateCustomField('cf_xyz', $request))->toBe($cfMock);
+});
+
+it('deleteCustomField accepts 200 or 204 and throws otherwise', function () {
+    $mocked = createMockedSdkWithCustomFields();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $ok = new Operations\CustomFieldsDeleteResponse(
+        contentType: 'application/json',
+        statusCode: 204,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['customFields']->shouldReceive('delete')->once()->andReturn($ok);
+    LaravelPolar::deleteCustomField('cf_ok');
+
+    $err = new Operations\CustomFieldsDeleteResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['customFields']->shouldReceive('delete')->once()->andReturn($err);
+    expect(fn() => LaravelPolar::deleteCustomField('cf_bad'))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('listCustomFields returns the first 200 page from the generator', function () {
+    $mocked = createMockedSdkWithCustomFields();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $list = new Components\ListResourceCustomField(
+        items: [Mockery::mock(Components\CustomFieldText::class)],
+        pagination: new Components\Pagination(totalCount: 1, maxPage: 1),
+    );
+
+    $response = new Operations\CustomFieldsListResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        listResourceCustomField: $list,
+    );
+
+    $mocked['customFields']->shouldReceive('list')->andReturn((function () use ($response) {
+        yield $response;
+    })());
+
+    $result = LaravelPolar::listCustomFields();
+
+    expect($result)->toBe($response);
+    expect($result->listResourceCustomField?->items)->toHaveCount(1);
+});
+
+it('getCustomField returns the custom field on 200', function () {
+    $mocked = createMockedSdkWithCustomFields();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $cfMock = Mockery::mock(Components\CustomFieldText::class);
+    $response = new Operations\CustomFieldsGetResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customField: $cfMock,
+    );
+
+    $mocked['customFields']->shouldReceive('get')->once()->with('cf_abc')->andReturn($response);
+
+    expect(LaravelPolar::getCustomField('cf_abc'))->toBe($cfMock);
+});
+
+it('getCustomField throws when SDK returns non-200', function () {
+    $mocked = createMockedSdkWithCustomFields();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\CustomFieldsGetResponse(
+        contentType: 'application/json',
+        statusCode: 404,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customField: null,
+    );
+
+    $mocked['customFields']->shouldReceive('get')->andReturn($response);
+
+    expect(fn() => LaravelPolar::getCustomField('cf_missing'))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('Order::customFieldData fetches from Polar and memoizes', function () {
+    $mocked = createMockedSdkWithOrders();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $order = Order::factory()->paid()->create(['polar_id' => 'ord_with_cf']);
+
+    $sdkOrder = Mockery::mock(Components\Order::class);
+    $sdkOrder->customFieldData = ['company' => 'Acme', 'volume' => 42];
+
+    $response = new Operations\OrdersGetResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        order: $sdkOrder,
+    );
+
+    $mocked['orders']->shouldReceive('get')
+        ->once() // Memoization: only called once even if accessed twice
+        ->withArgs(fn(string $id) => $id === 'ord_with_cf')
+        ->andReturn($response);
+
+    $first = $order->customFieldData();
+    $second = $order->customFieldData();
+
+    expect($first)->toBe(['company' => 'Acme', 'volume' => 42]);
+    expect($second)->toBe($first);
+});
+
+it('Order::customFieldData returns an empty array when the order has no polar_id', function () {
+    $order = Order::factory()->paid()->create(['polar_id' => null]);
+
+    expect($order->customFieldData())->toBe([]);
+});
+
+it('Order::customFieldData returns an empty array when the SDK returns no order', function () {
+    $mocked = createMockedSdkWithOrders();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $order = Order::factory()->paid()->create(['polar_id' => 'ord_phantom']);
+
+    $response = new Operations\OrdersGetResponse(
+        contentType: 'application/json',
+        statusCode: 404,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        order: null,
+    );
+
+    $mocked['orders']->shouldReceive('get')->andReturn($response);
+
+    expect($order->customFieldData())->toBe([]);
+});


### PR DESCRIPTION
## Summary

Adds the admin management surface for Polar custom fields via the \`LaravelPolar\` facade plus a memoized read accessor for the custom-field data collected at checkout.

Purely additive — no breaking changes. The checkout-time setter \`Checkout::withCustomFieldData()\` already shipped previously and is unchanged.

\`\`\`php
use Danestves\LaravelPolar\LaravelPolar;
use Polar\Models\Components;

LaravelPolar::createCustomField(new Components\CustomFieldCreateText(
    slug: 'company',
    name: 'Company name',
    properties: new Components\CustomFieldTextProperties(),
));
LaravelPolar::updateCustomField('cf_xxx', new Components\CustomFieldUpdateText(name: 'New label'));
LaravelPolar::deleteCustomField('cf_xxx');
LaravelPolar::listCustomFields();
LaravelPolar::getCustomField('cf_xxx');

// Read collected data from an Order (fetched on demand, memoized):
\$order->customFieldData();
\`\`\`

## What's in this PR

- Five new static facade methods on \`src/LaravelPolar.php\` matching the existing CRUD style.
- \`Order::customFieldData()\` method (memoized per instance) that fetches the order from Polar on demand and returns its \`customFieldData\` field.
- 9 new Pest tests covering CRUD happy paths and error paths, memoization, and empty fallbacks.
- VERSION constant bumped to \`2.7.0\`.
- \`docs/migration-v2.6-to-v2.7.md\` (purely additive — no user action required).

## Test plan

- [x] \`vendor/bin/pest\` — 152 tests pass (364 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.7.0\` on merge per the v2.x release flow.