### PR TITLE
feat(subscription): Cashier-style applyDiscount / removeDiscount

### DIFF
--- a/docs/migration-v2.7-to-v2.8.md
+++ b/docs/migration-v2.7-to-v2.8.md
@@ -1,0 +1,26 @@
+# Migrating from v2.7 to v2.8
+
+`v2.8.0` is **purely additive** — your existing code continues to work without changes.
+
+## What's new
+
+Two new Cashier-style methods on `Subscription` for managing discounts mid-subscription:
+
+```php
+$subscription->applyDiscount('disc_xxx');
+$subscription->removeDiscount();
+```
+
+Both methods proxy to the SDK's `SubscriptionUpdateDiscount` request and return `$this` (the synced `Subscription` model) so calls chain. The change is applied on the next billing cycle — same Polar semantics as setting `discount_id` directly on the SDK.
+
+`applyDiscount()` mirrors Laravel Cashier's `$subscription->applyCoupon()` ergonomic, finally closing a gap that existed since the v2.5 admin discount CRUD shipped — until now, the package could only apply discounts at checkout, not on an existing subscription.
+
+## Required user actions
+
+None. Pure addition — `composer update danestves/laravel-polar` and the new methods are available.
+
+## Notes
+
+- Polar applies the discount change on the **next billing cycle**, not immediately. There is no SDK option for proration on discount changes today.
+- `removeDiscount()` is equivalent to `applyDiscount(null)` at the SDK level; the explicit method exists for code clarity.
+- Both methods re-throw `Polar\Models\Errors\APIException` on a non-200 response from Polar, consistent with the rest of the package.

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.7.0';
+    public const string VERSION = '2.8.0';
 
     /**
      * The cached Polar SDK instance.

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -281,6 +281,22 @@ class Subscription extends Model // @phpstan-ignore-line propertyTag.trait - Bil
     }
 
     /**
+     * Apply a discount to this subscription on the next billing cycle.
+     */
+    public function applyDiscount(string $discountId): self
+    {
+        return $this->updateAndSync(new Components\SubscriptionUpdateDiscount(discountId: $discountId));
+    }
+
+    /**
+     * Remove any active discount from this subscription on the next billing cycle.
+     */
+    public function removeDiscount(): self
+    {
+        return $this->updateAndSync(new Components\SubscriptionUpdateDiscount(discountId: null));
+    }
+
+    /**
      * Update the subscription and sync the changes.
      *
      * @param Components\SubscriptionUpdateProduct|Components\SubscriptionCancel|Components\SubscriptionUpdateDiscount|Components\SubscriptionUpdateTrial|Components\SubscriptionUpdateSeats|Components\SubscriptionRevoke $request

--- a/tests/Feature/SubscriptionTest.php
+++ b/tests/Feature/SubscriptionTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use Danestves\LaravelPolar\Exceptions\PolarApiError;
-use Polar\Models\Components\SubscriptionStatus;
 use Danestves\LaravelPolar\Subscription;
 use Illuminate\Support\Facades\Config;
+use Polar\Models\Components;
+use Polar\Models\Components\SubscriptionStatus;
+use Polar\Models\Operations\SubscriptionsUpdateResponse;
 
 beforeEach(function () {
     Config::set('polar.access_token', 'test-token');
@@ -11,6 +13,7 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    resetLaravelPolarSdk();
     Mockery::close();
 });
 
@@ -174,4 +177,94 @@ it('throws exception when resuming incomplete expired subscription', function ()
 
     expect(fn() => $subscription->resume())
         ->toThrow(PolarApiError::class, 'Subscription is incomplete and expired.');
+});
+
+it('applyDiscount forwards SubscriptionUpdateDiscount with the discount id to the SDK', function () {
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $subscriptions = Mockery::mock(\Polar\Subscriptions::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $subscriptionsProperty = $reflectionSdk->getProperty('subscriptions');
+    $subscriptionsProperty->setAccessible(true);
+    $subscriptionsProperty->setValue($sdk, $subscriptions);
+
+    setLaravelPolarSdk($sdk);
+
+    $subscription = Subscription::factory()->active()->create([
+        'polar_id' => 'sub_apply',
+        'product_id' => 'prod_orig',
+    ]);
+
+    $sdkSubscription = Mockery::mock(Components\Subscription::class);
+    $sdkSubscription->status = SubscriptionStatus::Active;
+    $sdkSubscription->productId = 'prod_orig';
+    $sdkSubscription->currentPeriodEnd = new \DateTime('+30 days');
+    $sdkSubscription->trialEnd = null;
+    $sdkSubscription->endedAt = null;
+
+    $response = new SubscriptionsUpdateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        subscription: $sdkSubscription,
+    );
+
+    $subscriptions->shouldReceive('update')
+        ->once()
+        ->withArgs(function ($body, string $id) {
+            return $id === 'sub_apply'
+                && $body instanceof Components\SubscriptionUpdateDiscount
+                && $body->discountId === 'disc_holiday';
+        })
+        ->andReturn($response);
+
+    $result = $subscription->applyDiscount('disc_holiday');
+
+    expect($result)->toBe($subscription);
+});
+
+it('removeDiscount forwards SubscriptionUpdateDiscount with null discountId to the SDK', function () {
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $subscriptions = Mockery::mock(\Polar\Subscriptions::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $subscriptionsProperty = $reflectionSdk->getProperty('subscriptions');
+    $subscriptionsProperty->setAccessible(true);
+    $subscriptionsProperty->setValue($sdk, $subscriptions);
+
+    setLaravelPolarSdk($sdk);
+
+    $subscription = Subscription::factory()->active()->create([
+        'polar_id' => 'sub_remove',
+        'product_id' => 'prod_orig',
+    ]);
+
+    $sdkSubscription = Mockery::mock(Components\Subscription::class);
+    $sdkSubscription->status = SubscriptionStatus::Active;
+    $sdkSubscription->productId = 'prod_orig';
+    $sdkSubscription->currentPeriodEnd = new \DateTime('+30 days');
+    $sdkSubscription->trialEnd = null;
+    $sdkSubscription->endedAt = null;
+
+    $response = new SubscriptionsUpdateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        subscription: $sdkSubscription,
+    );
+
+    $subscriptions->shouldReceive('update')
+        ->once()
+        ->withArgs(function ($body, string $id) {
+            return $id === 'sub_remove'
+                && $body instanceof Components\SubscriptionUpdateDiscount
+                && $body->discountId === null;
+        })
+        ->andReturn($response);
+
+    $result = $subscription->removeDiscount();
+
+    expect($result)->toBe($subscription);
 });


### PR DESCRIPTION
## Summary

Closes the Cashier-parallel gap noted while reviewing the v2.5 admin Discount CRUD: until now the package could apply a discount at checkout (\`Checkout::withDiscountId\`) but not on an existing subscription. Cashier's equivalent is \`\$subscription->applyCoupon()\`.

\`\`\`php
\$subscription->applyDiscount('disc_xxx');  // apply a discount on next billing cycle
\$subscription->removeDiscount();            // remove any active discount
\`\`\`

Both methods return \`\$this\` for chaining; both proxy to the SDK's existing \`Components\SubscriptionUpdateDiscount\` request body.

## What's in this PR

- Two new methods on \`src/Subscription.php\`: \`applyDiscount(string \$discountId)\` and \`removeDiscount()\`.
- 2 new Pest tests in \`tests/Feature/SubscriptionTest.php\` covering the args forwarded to the SDK in each case.
- Updated imports at the top of \`tests/Feature/SubscriptionTest.php\` (was missing \`Components\` and \`SubscriptionsUpdateResponse\` aliases).
- VERSION constant bumped to \`2.8.0\`.
- \`docs/migration-v2.7-to-v2.8.md\` (purely additive — no user action required).

## Test plan

- [x] \`vendor/bin/pest\` — 154 tests pass (368 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.8.0\` on merge per the v2.x release flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription discount management capabilities: apply new discounts or remove existing ones, with changes taking effect on the next billing cycle (no proration support)

* **Documentation**
  * v2.8.0 migration guide added documenting the new discount management functionality and upgrade requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danestves/laravel-polar/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->