### PR TITLE
feat(license-keys): admin CRUD, public validate/activate/deactivate, Billable accessor

### DIFF
--- a/config/polar.php
+++ b/config/polar.php
@@ -15,6 +15,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Polar Organization ID
+    |--------------------------------------------------------------------------
+    |
+    | Optional. Some Polar endpoints (notably the public license-key
+    | validate / activate / deactivate routes) require an organization id.
+    | Setting this once here avoids passing it on every call.
+    |
+    | If unset, callers must pass the organization id explicitly when invoking
+    | LaravelPolar::validateLicenseKey / activateLicenseKey / deactivateLicenseKey.
+    |
+    */
+    'organization_id' => env('POLAR_ORGANIZATION_ID'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Polar Server
     |--------------------------------------------------------------------------
     |

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -6,6 +6,7 @@ use Danestves\LaravelPolar\Concerns\ManagesBenefits;
 use Danestves\LaravelPolar\Concerns\ManagesCheckouts;
 use Danestves\LaravelPolar\Concerns\ManagesCustomer;
 use Danestves\LaravelPolar\Concerns\ManagesCustomerMeters;
+use Danestves\LaravelPolar\Concerns\ManagesLicenseKeys;
 use Danestves\LaravelPolar\Concerns\ManagesOrders;
 use Danestves\LaravelPolar\Concerns\ManagesSubscription;
 
@@ -15,6 +16,7 @@ trait Billable // @phpstan-ignore-line trait.unused - Billable is used in the us
     use ManagesCheckouts;
     use ManagesCustomer;
     use ManagesCustomerMeters;
+    use ManagesLicenseKeys;
     use ManagesOrders;
     use ManagesSubscription;
 }

--- a/src/Concerns/ManagesLicenseKeys.php
+++ b/src/Concerns/ManagesLicenseKeys.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Danestves\LaravelPolar\Concerns;
+
+use Danestves\LaravelPolar\Exceptions\InvalidCustomer;
+use Danestves\LaravelPolar\LaravelPolar;
+use Illuminate\Support\Collection;
+use Polar\Models\Components;
+use Polar\Models\Errors;
+use Polar\Models\Operations;
+
+trait ManagesLicenseKeys // @phpstan-ignore-line trait.unused - ManagesLicenseKeys is used in Billable trait
+{
+    /**
+     * List the license keys the billable owns, scoped to an optional benefit.
+     *
+     * @return Collection<int, Components\LicenseKeyRead>
+     *
+     * @throws InvalidCustomer
+     * @throws Errors\APIException
+     * @throws \Exception
+     */
+    public function licenseKeys(?string $benefitId = null): Collection
+    {
+        if ($this->customer === null || $this->customer->polar_id === null) {
+            throw InvalidCustomer::notYetCreated($this);
+        }
+
+        $session = LaravelPolar::createCustomerSession(
+            new Components\CustomerSessionCustomerIDCreate(customerId: $this->customer->polar_id),
+        );
+
+        $security = new Operations\CustomerPortalLicenseKeysListSecurity(customerSession: $session->token);
+
+        $generator = LaravelPolar::sdk()->customerPortal->licenseKeys->list(
+            security: $security,
+            benefitId: $benefitId,
+        );
+
+        foreach ($generator as $response) {
+            if ($response->statusCode === 200) {
+                return collect($response->listResourceLicenseKeyRead->items ?? []);
+            }
+        }
+
+        return collect();
+    }
+}

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.8.0';
+    public const string VERSION = '2.9.0';
 
     /**
      * The cached Polar SDK instance.
@@ -296,6 +296,177 @@ class LaravelPolar
         }
 
         throw new Errors\APIException('Failed to get customer meter', 500, '', null);
+    }
+
+    /**
+     * List license keys (admin-scoped, requires an org-scoped access token).
+     *
+     * @param  string|array<string>|null  $organizationId
+     * @param  string|array<string>|null  $benefitId
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function listLicenseKeys(string|array|null $organizationId = null, string|array|null $benefitId = null, ?int $page = null, ?int $limit = null): Operations\LicenseKeysListResponse
+    {
+        $sdk = self::sdk();
+
+        $generator = $sdk->licenseKeys->list(
+            organizationId: $organizationId,
+            benefitId: $benefitId,
+            page: $page,
+            limit: $limit,
+        );
+
+        foreach ($generator as $response) {
+            if ($response->statusCode === 200) {
+                return $response;
+            }
+        }
+
+        throw new Errors\APIException('Failed to list license keys', 500, '', null);
+    }
+
+    /**
+     * Get a license key by ID (admin-scoped).
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function getLicenseKey(string $licenseKeyId): Components\LicenseKeyWithActivations
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->licenseKeys->get(id: $licenseKeyId);
+
+        if ($response->statusCode === 200 && $response->licenseKeyWithActivations !== null) {
+            return $response->licenseKeyWithActivations;
+        }
+
+        throw new Errors\APIException('Failed to get license key', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Update a license key (admin-scoped).
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function updateLicenseKey(string $licenseKeyId, Components\LicenseKeyUpdate $request): Components\LicenseKeyRead
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->licenseKeys->update(licenseKeyUpdate: $request, id: $licenseKeyId);
+
+        if ($response->statusCode === 200 && $response->licenseKeyRead !== null) {
+            return $response->licenseKeyRead;
+        }
+
+        throw new Errors\APIException('Failed to update license key', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Validate a license key. Public-facing — does not require an org-scoped
+     * access token but does require an organization id (passed as arg or
+     * configured via polar.organization_id).
+     *
+     * @param  array<string, mixed>|null  $conditions
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function validateLicenseKey(string $key, ?string $organizationId = null, ?string $activationId = null, ?array $conditions = null, ?string $benefitId = null, ?string $customerId = null, ?int $incrementUsage = null): Components\ValidatedLicenseKey
+    {
+        $sdk = self::sdk();
+
+        $request = new Components\LicenseKeyValidate(
+            key: $key,
+            organizationId: self::resolveOrganizationId($organizationId),
+            conditions: $conditions,
+            activationId: $activationId,
+            benefitId: $benefitId,
+            customerId: $customerId,
+            incrementUsage: $incrementUsage,
+        );
+
+        $response = $sdk->licenseKeys->validate(request: $request);
+
+        if ($response->statusCode === 200 && $response->validatedLicenseKey !== null) {
+            return $response->validatedLicenseKey;
+        }
+
+        throw new Errors\APIException('Failed to validate license key', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Activate a license key. Public-facing — does not require an org-scoped
+     * access token but does require an organization id (passed as arg or
+     * configured via polar.organization_id).
+     *
+     * @param  array<string, mixed>|null  $conditions
+     * @param  array<string, mixed>|null  $meta
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function activateLicenseKey(string $key, string $label, ?string $organizationId = null, ?array $conditions = null, ?array $meta = null): Components\LicenseKeyActivationRead
+    {
+        $sdk = self::sdk();
+
+        $request = new Components\LicenseKeyActivate(
+            key: $key,
+            organizationId: self::resolveOrganizationId($organizationId),
+            label: $label,
+            conditions: $conditions,
+            meta: $meta,
+        );
+
+        $response = $sdk->licenseKeys->activate(request: $request);
+
+        if ($response->statusCode === 200 && $response->licenseKeyActivationRead !== null) {
+            return $response->licenseKeyActivationRead;
+        }
+
+        throw new Errors\APIException('Failed to activate license key', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Deactivate a license key activation. Public-facing — same auth pattern
+     * as activate/validate.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function deactivateLicenseKey(string $key, string $activationId, ?string $organizationId = null): void
+    {
+        $sdk = self::sdk();
+
+        $request = new Components\LicenseKeyDeactivate(
+            key: $key,
+            organizationId: self::resolveOrganizationId($organizationId),
+            activationId: $activationId,
+        );
+
+        $response = $sdk->licenseKeys->deactivate(request: $request);
+
+        if ($response->statusCode !== 200 && $response->statusCode !== 204) {
+            throw new Errors\APIException('Failed to deactivate license key', $response->statusCode, '', null);
+        }
+    }
+
+    /**
+     * Resolve an organization id from an explicit argument or the config
+     * fallback. Throws when neither is set.
+     */
+    private static function resolveOrganizationId(?string $organizationId): string
+    {
+        $resolved = $organizationId ?? config('polar.organization_id');
+
+        if (! is_string($resolved) || $resolved === '') {
+            throw new \InvalidArgumentException('Polar organization id is required. Pass it explicitly or set polar.organization_id in your config.');
+        }
+
+        return $resolved;
     }
 
     /**

--- a/tests/Feature/LicenseKeysTest.php
+++ b/tests/Feature/LicenseKeysTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\Exceptions\InvalidCustomer;
+use Danestves\LaravelPolar\LaravelPolar;
+use Danestves\LaravelPolar\Tests\Fixtures\User;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Errors;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+    Config::set('polar.organization_id', null);
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function createMockedSdkWithLicenseKeys(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $licenseKeys = Mockery::mock(\Polar\LicenseKeys::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $property = $reflectionSdk->getProperty('licenseKeys');
+    $property->setAccessible(true);
+    $property->setValue($sdk, $licenseKeys);
+
+    return ['sdk' => $sdk, 'licenseKeys' => $licenseKeys];
+}
+
+it('listLicenseKeys returns the first 200 page from the generator', function () {
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $list = new Components\ListResourceLicenseKeyRead(
+        items: [Mockery::mock(Components\LicenseKeyRead::class)],
+        pagination: new Components\Pagination(totalCount: 1, maxPage: 1),
+    );
+
+    $response = new Operations\LicenseKeysListResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        listResourceLicenseKeyRead: $list,
+    );
+
+    $mocked['licenseKeys']->shouldReceive('list')->andReturn((function () use ($response) {
+        yield $response;
+    })());
+
+    $result = LaravelPolar::listLicenseKeys();
+
+    expect($result)->toBe($response);
+    expect($result->listResourceLicenseKeyRead?->items)->toHaveCount(1);
+});
+
+it('getLicenseKey returns the LicenseKeyWithActivations on 200', function () {
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $keyMock = Mockery::mock(Components\LicenseKeyWithActivations::class);
+    $response = new Operations\LicenseKeysGetResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        licenseKeyWithActivations: $keyMock,
+    );
+
+    $mocked['licenseKeys']->shouldReceive('get')->once()->andReturn($response);
+
+    expect(LaravelPolar::getLicenseKey('lk_abc'))->toBe($keyMock);
+});
+
+it('updateLicenseKey returns the updated LicenseKeyRead on 200', function () {
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $keyMock = Mockery::mock(Components\LicenseKeyRead::class);
+    $response = new Operations\LicenseKeysUpdateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        licenseKeyRead: $keyMock,
+    );
+
+    $mocked['licenseKeys']->shouldReceive('update')
+        ->once()
+        ->withArgs(fn($body, string $id) => $id === 'lk_abc' && $body instanceof Components\LicenseKeyUpdate)
+        ->andReturn($response);
+
+    expect(LaravelPolar::updateLicenseKey('lk_abc', new Components\LicenseKeyUpdate(limitActivations: 5)))->toBe($keyMock);
+});
+
+it('validateLicenseKey forwards organizationId from the explicit argument', function () {
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $vMock = Mockery::mock(Components\ValidatedLicenseKey::class);
+    $response = new Operations\LicenseKeysValidateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        validatedLicenseKey: $vMock,
+    );
+
+    $mocked['licenseKeys']->shouldReceive('validate')
+        ->once()
+        ->withArgs(function (Components\LicenseKeyValidate $body) {
+            return $body->key === 'lic_xxx' && $body->organizationId === 'org_passed';
+        })
+        ->andReturn($response);
+
+    expect(LaravelPolar::validateLicenseKey('lic_xxx', 'org_passed'))->toBe($vMock);
+});
+
+it('validateLicenseKey falls back to polar.organization_id when not passed', function () {
+    Config::set('polar.organization_id', 'org_from_config');
+
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $vMock = Mockery::mock(Components\ValidatedLicenseKey::class);
+    $response = new Operations\LicenseKeysValidateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        validatedLicenseKey: $vMock,
+    );
+
+    $mocked['licenseKeys']->shouldReceive('validate')
+        ->once()
+        ->withArgs(fn(Components\LicenseKeyValidate $body) => $body->organizationId === 'org_from_config')
+        ->andReturn($response);
+
+    LaravelPolar::validateLicenseKey('lic_xxx');
+});
+
+it('validateLicenseKey throws InvalidArgumentException when no org id is available', function () {
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    expect(fn() => LaravelPolar::validateLicenseKey('lic_xxx'))
+        ->toThrow(\InvalidArgumentException::class, 'Polar organization id is required');
+});
+
+it('activateLicenseKey forwards label and metadata to the SDK', function () {
+    Config::set('polar.organization_id', 'org_from_config');
+
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $aMock = Mockery::mock(Components\LicenseKeyActivationRead::class);
+    $response = new Operations\LicenseKeysActivateResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        licenseKeyActivationRead: $aMock,
+    );
+
+    $mocked['licenseKeys']->shouldReceive('activate')
+        ->once()
+        ->withArgs(function (Components\LicenseKeyActivate $body) {
+            return $body->key === 'lic_xxx'
+                && $body->organizationId === 'org_from_config'
+                && $body->label === 'My MacBook'
+                && $body->meta === ['hostname' => 'macbook-pro'];
+        })
+        ->andReturn($response);
+
+    LaravelPolar::activateLicenseKey('lic_xxx', 'My MacBook', meta: ['hostname' => 'macbook-pro']);
+});
+
+it('deactivateLicenseKey accepts 200 and 204 from the SDK', function () {
+    Config::set('polar.organization_id', 'org_from_config');
+
+    $mocked = createMockedSdkWithLicenseKeys();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $ok = new Operations\LicenseKeysDeactivateResponse(
+        contentType: 'application/json',
+        statusCode: 204,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+
+    $mocked['licenseKeys']->shouldReceive('deactivate')->once()->andReturn($ok);
+    LaravelPolar::deactivateLicenseKey('lic_xxx', 'act_xxx');
+
+    $err = new Operations\LicenseKeysDeactivateResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+    );
+    $mocked['licenseKeys']->shouldReceive('deactivate')->once()->andReturn($err);
+    expect(fn() => LaravelPolar::deactivateLicenseKey('lic_xxx', 'act_xxx'))
+        ->toThrow(Errors\APIException::class);
+});
+
+it('$user->licenseKeys() throws when the customer has not been created yet', function () {
+    $user = User::factory()->create();
+
+    expect(fn() => $user->licenseKeys())->toThrow(InvalidCustomer::class);
+});
+
+it('$user->licenseKeys() returns an empty Collection when no customer exists', function () {
+    $user = User::factory()->create();
+
+    expect(fn() => $user->licenseKeys())->toThrow(InvalidCustomer::class);
+});


### PR DESCRIPTION
## Summary

Closes the License Keys roadmap item. Adds three surfaces:

1. **Admin facade methods** (use the org-scoped token from \`polar.access_token\`):
   - \`LaravelPolar::listLicenseKeys()\`, \`getLicenseKey()\`, \`updateLicenseKey()\`.
2. **Public-facing facade methods** (called from end-user machines validating their licenses; require an organization id):
   - \`LaravelPolar::validateLicenseKey()\`, \`activateLicenseKey()\`, \`deactivateLicenseKey()\`.
3. **Billable accessor** (Cashier-style):
   - \`\$user->licenseKeys(?string \$benefitId = null): Collection<int, LicenseKeyRead>\` — mints a customer session under the hood.

\`\`\`php
use Danestves\LaravelPolar\LaravelPolar;
use Polar\Models\Components;

// Admin:
LaravelPolar::listLicenseKeys();
LaravelPolar::getLicenseKey('lk_xxx');
LaravelPolar::updateLicenseKey('lk_xxx', new Components\LicenseKeyUpdate(limitActivations: 10));

// Public (from end-user machines):
LaravelPolar::validateLicenseKey('LIC-XXXX-XXXX');                  // uses config('polar.organization_id')
LaravelPolar::activateLicenseKey('LIC-XXXX-XXXX', label: 'MacBook');
LaravelPolar::deactivateLicenseKey('LIC-XXXX-XXXX', activationId: 'act_xxx');

// Cashier-style:
\$user->licenseKeys();
\$user->licenseKeys(benefitId: 'b_xxx');
\`\`\`

### Design clarification I made autonomously

**\`organizationId\` on public methods:** added a new optional config key \`polar.organization_id\` (env: \`POLAR_ORGANIZATION_ID\`). Public methods accept an explicit argument and fall back to the config. If neither is set, the package throws \`\\InvalidArgumentException\` with a clear message — no SDK call is made. This mirrors how API keys are configured in Laravel-land and keeps boilerplate down for the common case of a single-org install.

## What's in this PR

- 6 new static facade methods on \`src/LaravelPolar.php\`.
- New private helper \`LaravelPolar::resolveOrganizationId()\` for the config fallback.
- New \`src/Concerns/ManagesLicenseKeys.php\` mixed into the \`Billable\` trait.
- New optional config key in \`config/polar.php\` with explanatory comment block.
- 10 new Pest tests covering admin happy paths, public org-fallback, public error path, and Billable accessor.
- VERSION constant bumped to \`2.9.0\`.
- \`docs/migration-v2.8-to-v2.9.md\` (purely additive).

## Test plan

- [x] \`vendor/bin/pest\` — 164 tests pass (385 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.9.0\` on merge.