### PR TITLE
feat(seats): admin CRUD + Cashier-style Subscription helpers

### DIFF
--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.10.0';
+    public const string VERSION = '2.11.0';
 
     /**
      * The cached Polar SDK instance.
@@ -296,6 +296,82 @@ class LaravelPolar
         }
 
         throw new Errors\APIException('Failed to get customer meter', 500, '', null);
+    }
+
+    /**
+     * List the seats on a subscription or order.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function listSeats(?string $subscriptionId = null, ?string $orderId = null): Components\SeatsList
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customerSeats->listSeats(subscriptionId: $subscriptionId, orderId: $orderId);
+
+        if ($response->statusCode === 200 && $response->seatsList !== null) {
+            return $response->seatsList;
+        }
+
+        throw new Errors\APIException('Failed to list seats', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Assign a seat to a member by email, customer id, or external id.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function assignSeat(Components\SeatAssign $request): Components\CustomerSeat
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customerSeats->assignSeat(request: $request);
+
+        if ($response->statusCode === 200 && $response->customerSeat !== null) {
+            return $response->customerSeat;
+        }
+
+        throw new Errors\APIException('Failed to assign seat', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Revoke a seat from a member.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function revokeSeat(string $seatId): Components\CustomerSeat
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customerSeats->revokeSeat(seatId: $seatId);
+
+        if ($response->statusCode === 200 && $response->customerSeat !== null) {
+            return $response->customerSeat;
+        }
+
+        throw new Errors\APIException('Failed to revoke seat', $response->statusCode ?? 500, '', null);
+    }
+
+    /**
+     * Resend the invitation email for a pending seat.
+     *
+     * @throws Errors\APIException
+     * @throws Exception
+     */
+    public static function resendSeatInvitation(string $seatId): Components\CustomerSeat
+    {
+        $sdk = self::sdk();
+
+        $response = $sdk->customerSeats->resendInvitation(seatId: $seatId);
+
+        if ($response->statusCode === 200 && $response->customerSeat !== null) {
+            return $response->customerSeat;
+        }
+
+        throw new Errors\APIException('Failed to resend seat invitation', $response->statusCode ?? 500, '', null);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -289,6 +289,49 @@ class Subscription extends Model // @phpstan-ignore-line propertyTag.trait - Bil
     }
 
     /**
+     * List the seats on this subscription.
+     */
+    public function seats(): Components\SeatsList
+    {
+        return LaravelPolar::listSeats(subscriptionId: $this->polar_id);
+    }
+
+    /**
+     * Assign a seat on this subscription to a member by email, customer id, or
+     * external customer id. Passing none of the three creates a pending seat
+     * that can be claimed via an invitation link.
+     *
+     * @param  array<string, mixed>|null  $metadata
+     */
+    public function assignSeat(?string $email = null, ?string $customerId = null, ?string $externalCustomerId = null, ?array $metadata = null, ?bool $immediateClaim = false): Components\CustomerSeat
+    {
+        return LaravelPolar::assignSeat(new Components\SeatAssign(
+            subscriptionId: $this->polar_id,
+            email: $email,
+            customerId: $customerId,
+            externalCustomerId: $externalCustomerId,
+            metadata: $metadata,
+            immediateClaim: $immediateClaim,
+        ));
+    }
+
+    /**
+     * Revoke a seat from this subscription.
+     */
+    public function revokeSeat(string $seatId): Components\CustomerSeat
+    {
+        return LaravelPolar::revokeSeat($seatId);
+    }
+
+    /**
+     * Resend the invitation email for a pending seat on this subscription.
+     */
+    public function resendSeatInvitation(string $seatId): Components\CustomerSeat
+    {
+        return LaravelPolar::resendSeatInvitation($seatId);
+    }
+
+    /**
      * Remove any active discount from this subscription on the next billing cycle.
      */
     public function removeDiscount(): self

--- a/tests/Feature/SeatsTest.php
+++ b/tests/Feature/SeatsTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\LaravelPolar;
+use Danestves\LaravelPolar\Subscription;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Errors;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function createMockedSdkWithCustomerSeats(): array
+{
+    $base = createBaseMockedSdk();
+    $sdk = $base['sdk'];
+
+    $customerSeats = Mockery::mock(\Polar\CustomerSeats::class);
+    $reflectionSdk = new \ReflectionClass($sdk);
+    $property = $reflectionSdk->getProperty('customerSeats');
+    $property->setAccessible(true);
+    $property->setValue($sdk, $customerSeats);
+
+    return ['sdk' => $sdk, 'customerSeats' => $customerSeats];
+}
+
+it('listSeats returns the SeatsList on 200', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $list = new Components\SeatsList(seats: [], availableSeats: 5, totalSeats: 10);
+    $response = new Operations\CustomerSeatsListSeatsResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        seatsList: $list,
+    );
+
+    $mocked['customerSeats']->shouldReceive('listSeats')
+        ->once()
+        ->andReturn($response);
+
+    expect(LaravelPolar::listSeats(subscriptionId: 'sub_xxx'))->toBe($list);
+});
+
+it('assignSeat returns the CustomerSeat on 200', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $seat = Mockery::mock(Components\CustomerSeat::class);
+    $response = new Operations\CustomerSeatsAssignSeatResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSeat: $seat,
+    );
+
+    $mocked['customerSeats']->shouldReceive('assignSeat')
+        ->once()
+        ->withArgs(fn(Components\SeatAssign $body) => $body->subscriptionId === 'sub_xxx' && $body->email === 'alice@example.com')
+        ->andReturn($response);
+
+    expect(LaravelPolar::assignSeat(new Components\SeatAssign(subscriptionId: 'sub_xxx', email: 'alice@example.com')))->toBe($seat);
+});
+
+it('revokeSeat returns the CustomerSeat on 200', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $seat = Mockery::mock(Components\CustomerSeat::class);
+    $response = new Operations\CustomerSeatsRevokeSeatResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSeat: $seat,
+    );
+
+    $mocked['customerSeats']->shouldReceive('revokeSeat')->once()->andReturn($response);
+
+    expect(LaravelPolar::revokeSeat('seat_xxx'))->toBe($seat);
+});
+
+it('resendSeatInvitation returns the CustomerSeat on 200', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $seat = Mockery::mock(Components\CustomerSeat::class);
+    $response = new Operations\CustomerSeatsResendInvitationResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSeat: $seat,
+    );
+
+    $mocked['customerSeats']->shouldReceive('resendInvitation')->once()->andReturn($response);
+
+    expect(LaravelPolar::resendSeatInvitation('seat_xxx'))->toBe($seat);
+});
+
+it('Subscription::seats calls listSeats with this subscription id', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $subscription = Subscription::factory()->active()->create(['polar_id' => 'sub_team']);
+
+    $list = new Components\SeatsList(seats: [], availableSeats: 3, totalSeats: 5);
+    $response = new Operations\CustomerSeatsListSeatsResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        seatsList: $list,
+    );
+
+    $mocked['customerSeats']->shouldReceive('listSeats')
+        ->once()
+        ->withArgs(fn(?string $subId, ?string $orderId) => $subId === 'sub_team' && $orderId === null)
+        ->andReturn($response);
+
+    expect($subscription->seats())->toBe($list);
+});
+
+it('Subscription::assignSeat forwards email, customerId, externalCustomerId, and metadata', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $subscription = Subscription::factory()->active()->create(['polar_id' => 'sub_team']);
+
+    $seat = Mockery::mock(Components\CustomerSeat::class);
+    $response = new Operations\CustomerSeatsAssignSeatResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSeat: $seat,
+    );
+
+    $mocked['customerSeats']->shouldReceive('assignSeat')
+        ->once()
+        ->withArgs(function (Components\SeatAssign $body) {
+            return $body->subscriptionId === 'sub_team'
+                && $body->email === 'alice@example.com'
+                && $body->customerId === 'cust_xx'
+                && $body->externalCustomerId === 'ext_yy'
+                && $body->metadata === ['role' => 'admin'];
+        })
+        ->andReturn($response);
+
+    $subscription->assignSeat(
+        email: 'alice@example.com',
+        customerId: 'cust_xx',
+        externalCustomerId: 'ext_yy',
+        metadata: ['role' => 'admin'],
+    );
+});
+
+it('Subscription::revokeSeat proxies to LaravelPolar::revokeSeat', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $subscription = Subscription::factory()->active()->create(['polar_id' => 'sub_team']);
+
+    $seat = Mockery::mock(Components\CustomerSeat::class);
+    $response = new Operations\CustomerSeatsRevokeSeatResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSeat: $seat,
+    );
+
+    $mocked['customerSeats']->shouldReceive('revokeSeat')
+        ->once()
+        ->withArgs(fn(string $seatId) => $seatId === 'seat_revoke')
+        ->andReturn($response);
+
+    expect($subscription->revokeSeat('seat_revoke'))->toBe($seat);
+});
+
+it('Subscription::resendSeatInvitation proxies to LaravelPolar::resendSeatInvitation', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $subscription = Subscription::factory()->active()->create(['polar_id' => 'sub_team']);
+
+    $seat = Mockery::mock(Components\CustomerSeat::class);
+    $response = new Operations\CustomerSeatsResendInvitationResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSeat: $seat,
+    );
+
+    $mocked['customerSeats']->shouldReceive('resendInvitation')
+        ->once()
+        ->withArgs(fn(string $seatId) => $seatId === 'seat_resend')
+        ->andReturn($response);
+
+    expect($subscription->resendSeatInvitation('seat_resend'))->toBe($seat);
+});
+
+it('listSeats throws when SDK returns non-200', function () {
+    $mocked = createMockedSdkWithCustomerSeats();
+    setLaravelPolarSdk($mocked['sdk']);
+
+    $response = new Operations\CustomerSeatsListSeatsResponse(
+        contentType: 'application/json',
+        statusCode: 500,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        seatsList: null,
+    );
+
+    $mocked['customerSeats']->shouldReceive('listSeats')->andReturn($response);
+
+    expect(fn() => LaravelPolar::listSeats(subscriptionId: 'sub_xxx'))
+        ->toThrow(Errors\APIException::class);
+});


### PR DESCRIPTION
## Summary

Adds team/seat management. Two complementary surfaces:

**Admin facade:**
\`\`\`php
LaravelPolar::listSeats(subscriptionId: 'sub_xxx');
LaravelPolar::assignSeat(new Components\SeatAssign(subscriptionId: 'sub_xxx', email: 'alice@example.com'));
LaravelPolar::revokeSeat('seat_xxx');
LaravelPolar::resendSeatInvitation('seat_xxx');
\`\`\`

**Cashier-style on Subscription:**
\`\`\`php
\$subscription->seats();                                   // SeatsList for this subscription
\$subscription->assignSeat(email: 'alice@example.com');    // pending seat + invitation email
\$subscription->revokeSeat('seat_xxx');
\$subscription->resendSeatInvitation('seat_xxx');
\`\`\`

## Design clarification I made autonomously

Polar's SDK exposes two clients for seats: \`Polar\Seats\` (uses customer-session security — for end-user self-service flows) and \`Polar\CustomerSeats\` (uses the org-scoped auth token directly — admin flow). I chose the **admin (\`CustomerSeats\`) client** for both the facade and the Cashier-style helpers because:

1. The package authenticates with the org token everywhere else.
2. App developers manage seats from server-side controllers, not from end-user browsers, so they don't need to mint a per-customer session for each call.
3. End-user self-service \"members\" flows are a separate use case (different security model, different UX). When demand arises that work belongs in a follow-up PR.

## What's in this PR

- 4 new static facade methods on \`src/LaravelPolar.php\`.
- 4 new Subscription methods on \`src/Subscription.php\` that proxy to the facade with the subscription's \`polar_id\` pre-filled.
- 9 new Pest tests covering admin happy paths, error paths, and Subscription proxying.
- VERSION constant bumped to \`2.11.0\`.
- \`docs/migration-v2.10-to-v2.11.md\` (purely additive — no user action required).

## Test plan

- [x] \`vendor/bin/pest\` — 178 tests pass (410 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.11.0\` on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seat management functionality for subscriptions and orders. Users can now list active seats, assign seats to customers, revoke seat access, and resend invitation emails for pending seats.

* **Tests**
  * Added comprehensive test coverage for seat management features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danestves/laravel-polar/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->