### PR TITLE
fix(inertia): auto-detect X-Inertia and return Inertia::location() to avoid CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,14 @@ LaravelPolar::listCheckoutLinks();           // optional CheckoutLinksListReques
 LaravelPolar::getCheckoutLink('cl_xxx');     // Components\CheckoutLink
 ```
 
+#### Inertia.js compatibility
+
+The `Checkout` Responsable and `$user->redirectToCustomerPortal()` auto-detect Inertia requests via the `X-Inertia` header and return `Inertia::location($url)` instead of a plain redirect. This avoids CORS errors when Inertia's XHR-based client tries to follow a redirect to an external host like `polar.sh`. No setup needed — works out of the box when `inertiajs/inertia-laravel` is installed.
+
+For non-Inertia callers (Blade, JSON APIs, console), the behavior is unchanged — a standard `RedirectResponse` to the external URL.
+
+If you prefer to handle the redirect yourself, call `$checkout->url()` or `$user->customerPortalUrl()` directly and route the URL however you like.
+
 ### Prefill Customer Information
 
 You can override the user data using the following methods in your models provided by the `Billable` trait.

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "standard-webhooks/standard-webhooks": "^1.0"
     },
     "require-dev": {
+        "inertiajs/inertia-laravel": "^3.1",
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.2",
         "mockery/mockery": "^1.5",

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -258,9 +258,15 @@ class Checkout implements Responsable
         return $this;
     }
 
-    public function toResponse($request): RedirectResponse
+    public function toResponse($request): \Symfony\Component\HttpFoundation\Response
     {
-        return $this->redirect();
+        $url = $this->url();
+
+        if ($request->header('X-Inertia') === 'true' && class_exists(\Inertia\Inertia::class)) {
+            return \Inertia\Inertia::location($url);
+        }
+
+        return Redirect::to($url, 303);
     }
 
     public function redirect(): RedirectResponse

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -51,10 +51,22 @@ trait ManagesCustomer // @phpstan-ignore-line trait.unused - ManagesCustomer is 
 
     /**
      * Generate a redirect response to the billable's customer portal.
+     *
+     * Returns an Inertia::location response when invoked from an Inertia
+     * request (detected via the X-Inertia header). This avoids CORS errors
+     * when Inertia's XHR-based client tries to follow a redirect to an
+     * external host. Falls back to a standard RedirectResponse otherwise.
      */
-    public function redirectToCustomerPortal(): RedirectResponse
+    public function redirectToCustomerPortal(): \Symfony\Component\HttpFoundation\Response
     {
-        return new RedirectResponse($this->customerPortalUrl());
+        $url = $this->customerPortalUrl();
+
+        $request = request();
+        if ($request->header('X-Inertia') === 'true' && class_exists(\Inertia\Inertia::class)) {
+            return \Inertia\Inertia::location($url);
+        }
+
+        return new RedirectResponse($url);
     }
 
     /**

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.13.0';
+    public const string VERSION = '2.13.1';
 
     /**
      * The cached Polar SDK instance.

--- a/tests/Feature/CheckoutInertiaTest.php
+++ b/tests/Feature/CheckoutInertiaTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\Checkout;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+it('Checkout::toResponse returns Inertia::location response when called from an Inertia request', function () {
+    $checkout = Mockery::mock(Checkout::class)->makePartial();
+    $checkout->shouldReceive('url')->andReturn('https://sandbox.polar.sh/checkout/polar_c_test');
+
+    // Inertia::location() checks the global request via Request::inertia(), so
+    // set the header on the container request as well as the passed request.
+    $request = \Illuminate\Http\Request::create('http://localhost/billing/checkout', 'POST');
+    $request->headers->set('X-Inertia', 'true');
+    app()->instance('request', $request);
+
+    $response = $checkout->toResponse($request);
+
+    expect($response->getStatusCode())->toBe(409);
+    expect($response->headers->get('X-Inertia-Location'))->toBe('https://sandbox.polar.sh/checkout/polar_c_test');
+});
+
+it('Checkout::toResponse returns a 303 redirect when called from a non-Inertia request', function () {
+    $checkout = Mockery::mock(Checkout::class)->makePartial();
+    $checkout->shouldReceive('url')->andReturn('https://sandbox.polar.sh/checkout/polar_c_test');
+
+    $request = \Illuminate\Http\Request::create('http://localhost/billing/checkout', 'POST');
+    app()->instance('request', $request);
+
+    $response = $checkout->toResponse($request);
+
+    expect($response->getStatusCode())->toBe(303);
+    expect($response->headers->get('Location'))->toBe('https://sandbox.polar.sh/checkout/polar_c_test');
+});
+
+it('Checkout::redirect always returns a plain 303 regardless of the Inertia header', function () {
+    $checkout = Mockery::mock(Checkout::class)->makePartial();
+    $checkout->shouldReceive('url')->andReturn('https://sandbox.polar.sh/checkout/polar_c_test');
+
+    $response = $checkout->redirect();
+
+    expect($response->getStatusCode())->toBe(303);
+    expect($response->headers->get('Location'))->toBe('https://sandbox.polar.sh/checkout/polar_c_test');
+});

--- a/tests/Feature/CustomerPortalInertiaTest.php
+++ b/tests/Feature/CustomerPortalInertiaTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Danestves\LaravelPolar\Customer;
+use Danestves\LaravelPolar\Tests\Fixtures\User;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+use Polar\Models\Components;
+use Polar\Models\Operations;
+
+beforeEach(function () {
+    Config::set('polar.access_token', 'test-token');
+    Config::set('polar.server', 'sandbox');
+});
+
+afterEach(function () {
+    resetLaravelPolarSdk();
+    Mockery::close();
+});
+
+function stubCustomerSessionForPortal(string $portalUrl = 'https://polar.sh/portal/cs_token'): void
+{
+    $base = createBaseMockedSdk();
+    setLaravelPolarSdk($base['sdk']);
+
+    $customerSessions = Mockery::mock(\Polar\CustomerSessions::class);
+    $reflectionSdk = new \ReflectionClass($base['sdk']);
+    $property = $reflectionSdk->getProperty('customerSessions');
+    $property->setAccessible(true);
+    $property->setValue($base['sdk'], $customerSessions);
+
+    $session = Mockery::mock(Components\CustomerSession::class);
+    $session->token = 'cs_token';
+    $session->customerPortalUrl = $portalUrl;
+
+    $response = new Operations\CustomerSessionsCreateResponse(
+        contentType: 'application/json',
+        statusCode: 201,
+        rawResponse: Mockery::mock(\Psr\Http\Message\ResponseInterface::class),
+        customerSession: $session,
+    );
+
+    $customerSessions->shouldReceive('create')->andReturn($response);
+}
+
+it('redirectToCustomerPortal returns Inertia::location when called from an Inertia request', function () {
+    stubCustomerSessionForPortal('https://polar.sh/portal/cs_token');
+
+    $user = User::factory()->create();
+    $user->customer()->save(new Customer(['polar_id' => 'cust_xyz']));
+    $user = $user->fresh();
+
+    $request = \Illuminate\Http\Request::create('http://localhost/billing/portal', 'GET');
+    $request->headers->set('X-Inertia', 'true');
+    app()->instance('request', $request);
+
+    $response = $user->redirectToCustomerPortal();
+
+    expect($response->getStatusCode())->toBe(409);
+    expect($response->headers->get('X-Inertia-Location'))->toBe('https://polar.sh/portal/cs_token');
+});
+
+it('redirectToCustomerPortal returns a plain redirect when called from a non-Inertia request', function () {
+    stubCustomerSessionForPortal('https://polar.sh/portal/cs_token');
+
+    $user = User::factory()->create();
+    $user->customer()->save(new Customer(['polar_id' => 'cust_xyz']));
+    $user = $user->fresh();
+
+    $request = \Illuminate\Http\Request::create('http://localhost/billing/portal', 'GET');
+    app()->instance('request', $request);
+
+    $response = $user->redirectToCustomerPortal();
+
+    expect($response)->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class);
+    expect($response->getTargetUrl())->toBe('https://polar.sh/portal/cs_token');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,6 +28,7 @@ class TestCase extends Orchestra
     {
         return [
             LaravelPolarServiceProvider::class,
+            \Inertia\ServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Summary

\`Checkout::toResponse()\` and \`\$user->redirectToCustomerPortal()\` unconditionally returned a \`RedirectResponse\` to an external \`polar.sh\` URL. That works for Blade apps but breaks Inertia.js apps:

- Inertia's client submits forms via XHR.
- The browser tries to follow a 303 to \`polar.sh\` via XHR.
- CORS preflight fires against \`polar.sh\`, which doesn't include \`Access-Control-Allow-Origin\` (legitimately — it's not a CORS-enabled origin).
- Submission fails:
  \`\`\`
  Access to XMLHttpRequest at 'https://sandbox.polar.sh/checkout/polar_c_xxx'
  ... has been blocked by CORS policy
  \`\`\`

The Inertia escape hatch is \`Inertia::location(\$url)\` — returns HTTP 409 with \`X-Inertia-Location\`, which the Inertia JS client handles by doing a full browser navigation (not XHR), bypassing CORS.

This PR auto-detects Inertia requests via the \`X-Inertia\` header and switches to that path. Non-Inertia callers see no change.

## What's in this PR

- \`src/Checkout.php\` — \`toResponse()\` widened from \`RedirectResponse\` to its parent \`Symfony\\Component\\HttpFoundation\\Response\` (LSP-safe). \`X-Inertia: true\` callers get \`Inertia::location()\`; everyone else gets the original \`Redirect::to(\$url, 303)\`. The standalone \`redirect()\` method is unchanged.
- \`src/Concerns/ManagesCustomer.php\` — \`redirectToCustomerPortal()\` widened the same way; uses \`request()\` since the trait method isn't router-dispatched.
- \`tests/Feature/CheckoutInertiaTest.php\` — 3 tests: Inertia path, non-Inertia path, and \`redirect()\` is unchanged.
- \`tests/Feature/CustomerPortalInertiaTest.php\` — 2 tests: Inertia path and non-Inertia path.
- \`tests/TestCase.php\` — registers \`Inertia\\ServiceProvider\` so \`Inertia::location()\` can call its \`Request::inertia()\` macro in tests.
- \`composer.json\` — \`inertiajs/inertia-laravel\` added as a dev dependency.
- Inertia detection is gated behind \`class_exists(\\Inertia\\Inertia::class)\`, so the package keeps **zero hard dependency** on Inertia.
- VERSION → \`2.13.1\`.
- README gets a new \`#### Inertia.js compatibility\` subsection under Checkouts.
- New \`docs/migration-v2.13.0-to-v2.13.1.md\` walks through the fix and the LSP-safe return-type widening.

## Test plan

- [x] \`vendor/bin/pest\` — 195 tests pass (439 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across the PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.13.1\` (patch) on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.13.1

* **New Features**
  * Added seamless Inertia.js support for checkout and customer portal redirects, automatically detecting Inertia requests and handling redirects without CORS issues.

* **Documentation**
  * Added documentation covering Inertia.js compatibility and manual redirect handling options.

* **Tests**
  * Added comprehensive test coverage for Inertia.js redirect behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danestves/laravel-polar/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->