### PR TITLE
fix(ingestEvents): accept any 2xx as success

### DIFF
--- a/docs/migration-v2.13.1-to-v2.13.2.md
+++ b/docs/migration-v2.13.1-to-v2.13.2.md
@@ -1,0 +1,30 @@
+# Migrating from v2.13.1 to v2.13.2
+
+`v2.13.2` is a **bug fix release**. No required action.
+
+## What's fixed
+
+`LaravelPolar::ingestEvents()` (and by extension `$user->ingestUsageEvent()` / `$user->ingestUsageEvents()`) used to throw `Failed to ingest events` on every successful call, because the status check looked for HTTP `202` but Polar's `/v1/events/ingest` endpoint actually returns `200`.
+
+The check is now any `2xx` is success:
+
+```php
+// Before:
+if ($response->statusCode !== 202) { throw ... }
+
+// After:
+if ($response->statusCode < 200 || $response->statusCode >= 300) { throw ... }
+```
+
+This matches HTTP convention and is robust to Polar tweaking the exact code (e.g. `200` → `202` in the future).
+
+## Required user actions
+
+None. If you were wrapping `ingestUsageEvent` calls in try/catch to suppress the false-positive exception, you can remove the wrapper — the call now succeeds silently on the happy path.
+
+If you weren't catching it, you were previously getting unexplained 500s in your logs. Those should stop.
+
+## Notes
+
+- Behavior on real failure (4xx/5xx from Polar) is unchanged — `Polar\Models\Errors\APIException` is still thrown, same shape as before.
+- No public API changed. No signature changed.

--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Polar\Polar;
 
 class LaravelPolar
 {
-    public const string VERSION = '2.13.1';
+    public const string VERSION = '2.13.2';
 
     /**
      * The cached Polar SDK instance.
@@ -253,7 +253,7 @@ class LaravelPolar
 
         $response = $sdk->events->ingest(request: $request);
 
-        if ($response->statusCode !== 202) {
+        if ($response->statusCode < 200 || $response->statusCode >= 300) {
             throw new Errors\APIException('Failed to ingest events', 500, '', null);
         }
     }

--- a/tests/Feature/CustomerMetersTest.php
+++ b/tests/Feature/CustomerMetersTest.php
@@ -281,3 +281,69 @@ it('throws exception when ingesting events fails', function () {
     expect(fn() => LaravelPolar::ingestEvents($request))
         ->toThrow(Errors\APIException::class);
 });
+
+it('treats a 200 response from ingestEvents as success', function () {
+    $mocked = createMockedSdkWithEvents();
+    $sdk = $mocked['sdk'];
+    $events = $mocked['events'];
+    $mockRawResponse = Mockery::mock(ResponseInterface::class);
+
+    $response = new Operations\EventsIngestResponse(
+        contentType: 'application/json',
+        statusCode: 200,
+        rawResponse: $mockRawResponse,
+    );
+
+    $events->shouldReceive('ingest')->once()->andReturn($response);
+
+    setLaravelPolarSdk($sdk);
+
+    $request = new Components\EventsIngest(events: []);
+
+    expect(fn() => LaravelPolar::ingestEvents($request))
+        ->not->toThrow(Errors\APIException::class);
+});
+
+it('treats a 202 response from ingestEvents as success', function () {
+    $mocked = createMockedSdkWithEvents();
+    $sdk = $mocked['sdk'];
+    $events = $mocked['events'];
+    $mockRawResponse = Mockery::mock(ResponseInterface::class);
+
+    $response = new Operations\EventsIngestResponse(
+        contentType: 'application/json',
+        statusCode: 202,
+        rawResponse: $mockRawResponse,
+    );
+
+    $events->shouldReceive('ingest')->once()->andReturn($response);
+
+    setLaravelPolarSdk($sdk);
+
+    $request = new Components\EventsIngest(events: []);
+
+    expect(fn() => LaravelPolar::ingestEvents($request))
+        ->not->toThrow(Errors\APIException::class);
+});
+
+it('throws when ingestEvents returns a 4xx status', function () {
+    $mocked = createMockedSdkWithEvents();
+    $sdk = $mocked['sdk'];
+    $events = $mocked['events'];
+    $mockRawResponse = Mockery::mock(ResponseInterface::class);
+
+    $response = new Operations\EventsIngestResponse(
+        contentType: 'application/json',
+        statusCode: 400,
+        rawResponse: $mockRawResponse,
+    );
+
+    $events->shouldReceive('ingest')->once()->andReturn($response);
+
+    setLaravelPolarSdk($sdk);
+
+    $request = new Components\EventsIngest(events: []);
+
+    expect(fn() => LaravelPolar::ingestEvents($request))
+        ->toThrow(Errors\APIException::class);
+});


### PR DESCRIPTION
## Summary

\`LaravelPolar::ingestEvents()\` (used by \`\$user->ingestUsageEvent()\` and \`\$user->ingestUsageEvents()\`) threw \`Failed to ingest events\` on every successful call.

Polar's \`/v1/events/ingest\` endpoint actually returns HTTP **200** with body \`{\"inserted\": N, \"duplicates\": N}\`, not 202 as previously assumed. Every successful ingestion was misreported as failure: consumers wrapping in try/catch saw false alarms, consumers without try/catch got unexplained 500s.

## The fix

\`\`\`php
// Before:
if (\$response->statusCode !== 202) { throw ... }

// After:
if (\$response->statusCode < 200 || \$response->statusCode >= 300) { throw ... }
\`\`\`

Matches HTTP convention (any 2xx is success) and is robust to Polar tweaking the exact code in the future.

## What's in this PR

- One-line fix in \`src/LaravelPolar.php::ingestEvents()\`.
- 3 new Pest tests appended to \`tests/Feature/CustomerMetersTest.php\`: 200 succeeds, 202 succeeds, 400 throws.
- VERSION constant bumped to \`2.13.2\`.
- \`docs/migration-v2.13.1-to-v2.13.2.md\` explains the fix.

## Test plan

- [x] \`vendor/bin/pest\` — 198 tests pass (445 assertions)
- [x] \`vendor/bin/phpstan analyse\` — no errors
- [x] \`vendor/bin/pint --test\` — no style violations
- [ ] CI confirms across the PHP 8.3/8.4 × Laravel 11/12 × Linux/Windows matrix

## Release plan

Tag \`v2.13.2\` (patch) on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event ingestion to correctly handle HTTP 2xx responses as successful operations, ensuring robust error handling for API interactions.

* **Documentation**
  * Added migration guide for v2.13.2 documenting event ingestion behavior changes and clarifying no user actions are required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danestves/laravel-polar/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->