### PR TITLE
fix: support Polar timestamps with microseconds

### DIFF
--- a/src/Data/Address.php
+++ b/src/Data/Address.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\CountryAlpha2;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Address extends Data
+class Address extends PolarData
 {
     public function __construct(
         public readonly CountryAlpha2 $country,

--- a/src/Data/AddressInput.php
+++ b/src/Data/AddressInput.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\CountryAlpha2;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class AddressInput extends Data
+class AddressInput extends PolarData
 {
     public function __construct(
         public readonly CountryAlpha2 $country,

--- a/src/Data/AttachedCustomField.php
+++ b/src/Data/AttachedCustomField.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema of a custom field attached to a resource.
  */
 #[MapName(SnakeCaseMapper::class)]
-class AttachedCustomField extends Data
+class AttachedCustomField extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Benefit.php
+++ b/src/Data/Benefit.php
@@ -8,14 +8,14 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class Benefit extends Data implements PropertyMorphableData
+abstract class Benefit extends PolarData implements PropertyMorphableData
 {
     /**
      * The ID of the benefit.

--- a/src/Data/BenefitCustomCreate.php
+++ b/src/Data/BenefitCustomCreate.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a benefit of type `custom`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitCustomCreate extends Data implements BenefitCreate
+class BenefitCustomCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitCustomCreateProperties.php
+++ b/src/Data/BenefitCustomCreateProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for creating a benefit of type `custom`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitCustomCreateProperties extends Data
+class BenefitCustomCreateProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $note = null,

--- a/src/Data/BenefitCustomProperties.php
+++ b/src/Data/BenefitCustomProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for a benefit of type `custom`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitCustomProperties extends Data
+class BenefitCustomProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $note,

--- a/src/Data/BenefitCustomUpdate.php
+++ b/src/Data/BenefitCustomUpdate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitCustomUpdate extends Data
+class BenefitCustomUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDiscordCreate.php
+++ b/src/Data/BenefitDiscordCreate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDiscordCreate extends Data implements BenefitCreate
+class BenefitDiscordCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDiscordCreateProperties.php
+++ b/src/Data/BenefitDiscordCreateProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties to create a benefit of type `discord`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDiscordCreateProperties extends Data
+class BenefitDiscordCreateProperties extends PolarData
 {
     public function __construct(
         public readonly string $guildToken,

--- a/src/Data/BenefitDiscordProperties.php
+++ b/src/Data/BenefitDiscordProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for a benefit of type `discord`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDiscordProperties extends Data
+class BenefitDiscordProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDiscordUpdate.php
+++ b/src/Data/BenefitDiscordUpdate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDiscordUpdate extends Data
+class BenefitDiscordUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDownloadablesCreate.php
+++ b/src/Data/BenefitDownloadablesCreate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDownloadablesCreate extends Data implements BenefitCreate
+class BenefitDownloadablesCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDownloadablesCreateProperties.php
+++ b/src/Data/BenefitDownloadablesCreateProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDownloadablesCreateProperties extends Data
+class BenefitDownloadablesCreateProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDownloadablesProperties.php
+++ b/src/Data/BenefitDownloadablesProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDownloadablesProperties extends Data
+class BenefitDownloadablesProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitDownloadablesUpdate.php
+++ b/src/Data/BenefitDownloadablesUpdate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitDownloadablesUpdate extends Data
+class BenefitDownloadablesUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitFeatureFlagCreate.php
+++ b/src/Data/BenefitFeatureFlagCreate.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a benefit of type `feature_flag`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitFeatureFlagCreate extends Data implements BenefitCreate
+class BenefitFeatureFlagCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitFeatureFlagCreateProperties.php
+++ b/src/Data/BenefitFeatureFlagCreateProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for creating a benefit of type `feature_flag`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitFeatureFlagCreateProperties extends Data {}
+class BenefitFeatureFlagCreateProperties extends PolarData {}

--- a/src/Data/BenefitFeatureFlagProperties.php
+++ b/src/Data/BenefitFeatureFlagProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for a benefit of type `feature_flag`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitFeatureFlagProperties extends Data {}
+class BenefitFeatureFlagProperties extends PolarData {}

--- a/src/Data/BenefitFeatureFlagUpdate.php
+++ b/src/Data/BenefitFeatureFlagUpdate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitFeatureFlagUpdate extends Data
+class BenefitFeatureFlagUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGitHubRepositoryCreate.php
+++ b/src/Data/BenefitGitHubRepositoryCreate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGitHubRepositoryCreate extends Data implements BenefitCreate
+class BenefitGitHubRepositoryCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGitHubRepositoryCreateProperties.php
+++ b/src/Data/BenefitGitHubRepositoryCreateProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties to create a benefit of type `github_repository`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGitHubRepositoryCreateProperties extends Data
+class BenefitGitHubRepositoryCreateProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGitHubRepositoryProperties.php
+++ b/src/Data/BenefitGitHubRepositoryProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for a benefit of type `github_repository`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGitHubRepositoryProperties extends Data
+class BenefitGitHubRepositoryProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGitHubRepositoryUpdate.php
+++ b/src/Data/BenefitGitHubRepositoryUpdate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGitHubRepositoryUpdate extends Data
+class BenefitGitHubRepositoryUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGrant.php
+++ b/src/Data/BenefitGrant.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrant extends Data
+class BenefitGrant extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGrantCustomProperties.php
+++ b/src/Data/BenefitGrantCustomProperties.php
@@ -6,9 +6,9 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantCustomProperties extends Data {}
+class BenefitGrantCustomProperties extends PolarData {}

--- a/src/Data/BenefitGrantDiscordProperties.php
+++ b/src/Data/BenefitGrantDiscordProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantDiscordProperties extends Data
+class BenefitGrantDiscordProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $accountId = null,

--- a/src/Data/BenefitGrantDownloadablesProperties.php
+++ b/src/Data/BenefitGrantDownloadablesProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantDownloadablesProperties extends Data
+class BenefitGrantDownloadablesProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitGrantError.php
+++ b/src/Data/BenefitGrantError.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantError extends Data
+class BenefitGrantError extends PolarData
 {
     public function __construct(
         public readonly string $message,

--- a/src/Data/BenefitGrantFeatureFlagProperties.php
+++ b/src/Data/BenefitGrantFeatureFlagProperties.php
@@ -6,9 +6,9 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantFeatureFlagProperties extends Data {}
+class BenefitGrantFeatureFlagProperties extends PolarData {}

--- a/src/Data/BenefitGrantGitHubRepositoryProperties.php
+++ b/src/Data/BenefitGrantGitHubRepositoryProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantGitHubRepositoryProperties extends Data
+class BenefitGrantGitHubRepositoryProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $accountId = null,

--- a/src/Data/BenefitGrantLicenseKeysProperties.php
+++ b/src/Data/BenefitGrantLicenseKeysProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantLicenseKeysProperties extends Data
+class BenefitGrantLicenseKeysProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $userProvidedKey = null,

--- a/src/Data/BenefitGrantMeterCreditProperties.php
+++ b/src/Data/BenefitGrantMeterCreditProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantMeterCreditProperties extends Data
+class BenefitGrantMeterCreditProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $lastCreditedMeterId = null,

--- a/src/Data/BenefitGrantSlackSharedChannelProperties.php
+++ b/src/Data/BenefitGrantSlackSharedChannelProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitGrantSlackSharedChannelProperties extends Data
+class BenefitGrantSlackSharedChannelProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $invitedEmail = null,

--- a/src/Data/BenefitGrantWebhook.php
+++ b/src/Data/BenefitGrantWebhook.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class BenefitGrantWebhook extends Data
+abstract class BenefitGrantWebhook extends PolarData
 {
     /**
      * Creation timestamp of the object.

--- a/src/Data/BenefitLicenseKeyActivationCreateProperties.php
+++ b/src/Data/BenefitLicenseKeyActivationCreateProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeyActivationCreateProperties extends Data
+class BenefitLicenseKeyActivationCreateProperties extends PolarData
 {
     public function __construct(
         public readonly int $limit,

--- a/src/Data/BenefitLicenseKeyActivationProperties.php
+++ b/src/Data/BenefitLicenseKeyActivationProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeyActivationProperties extends Data
+class BenefitLicenseKeyActivationProperties extends PolarData
 {
     public function __construct(
         public readonly int $limit,

--- a/src/Data/BenefitLicenseKeyExpirationProperties.php
+++ b/src/Data/BenefitLicenseKeyExpirationProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeyExpirationProperties extends Data
+class BenefitLicenseKeyExpirationProperties extends PolarData
 {
     public function __construct(
         public readonly int $ttl,

--- a/src/Data/BenefitLicenseKeysCreate.php
+++ b/src/Data/BenefitLicenseKeysCreate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeysCreate extends Data implements BenefitCreate
+class BenefitLicenseKeysCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitLicenseKeysCreateProperties.php
+++ b/src/Data/BenefitLicenseKeysCreateProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeysCreateProperties extends Data
+class BenefitLicenseKeysCreateProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $prefix = null,

--- a/src/Data/BenefitLicenseKeysProperties.php
+++ b/src/Data/BenefitLicenseKeysProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeysProperties extends Data
+class BenefitLicenseKeysProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $prefix,

--- a/src/Data/BenefitLicenseKeysUpdate.php
+++ b/src/Data/BenefitLicenseKeysUpdate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitLicenseKeysUpdate extends Data
+class BenefitLicenseKeysUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitMeterCreditCreate.php
+++ b/src/Data/BenefitMeterCreditCreate.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a benefit of type `meter_unit`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitMeterCreditCreate extends Data implements BenefitCreate
+class BenefitMeterCreditCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitMeterCreditCreateProperties.php
+++ b/src/Data/BenefitMeterCreditCreateProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for creating a benefit of type `meter_unit`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitMeterCreditCreateProperties extends Data
+class BenefitMeterCreditCreateProperties extends PolarData
 {
     public function __construct(
         public readonly int $units,

--- a/src/Data/BenefitMeterCreditProperties.php
+++ b/src/Data/BenefitMeterCreditProperties.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Properties for a benefit of type `meter_unit`.
  */
 #[MapName(SnakeCaseMapper::class)]
-class BenefitMeterCreditProperties extends Data
+class BenefitMeterCreditProperties extends PolarData
 {
     public function __construct(
         public readonly int $units,

--- a/src/Data/BenefitMeterCreditUpdate.php
+++ b/src/Data/BenefitMeterCreditUpdate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitMeterCreditUpdate extends Data
+class BenefitMeterCreditUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitPublic.php
+++ b/src/Data/BenefitPublic.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\BenefitType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitPublic extends Data
+class BenefitPublic extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitSlackSharedChannelCreate.php
+++ b/src/Data/BenefitSlackSharedChannelCreate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BenefitVisibility;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitSlackSharedChannelCreate extends Data implements BenefitCreate
+class BenefitSlackSharedChannelCreate extends PolarData implements BenefitCreate
 {
     public function __construct(
         /**

--- a/src/Data/BenefitSlackSharedChannelCreateProperties.php
+++ b/src/Data/BenefitSlackSharedChannelCreateProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitSlackSharedChannelCreateProperties extends Data
+class BenefitSlackSharedChannelCreateProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitSlackSharedChannelProperties.php
+++ b/src/Data/BenefitSlackSharedChannelProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitSlackSharedChannelProperties extends Data
+class BenefitSlackSharedChannelProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/BenefitSlackSharedChannelUpdate.php
+++ b/src/Data/BenefitSlackSharedChannelUpdate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class BenefitSlackSharedChannelUpdate extends Data
+class BenefitSlackSharedChannelUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Checkout.php
+++ b/src/Data/Checkout.php
@@ -11,15 +11,15 @@ use Danestves\LaravelPolar\Enums\CheckoutStatus;
 use Danestves\LaravelPolar\Enums\PaymentProcessor;
 use Danestves\LaravelPolar\Enums\TaxBehavior;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Checkout session data retrieved using an access token.
  */
 #[MapName(SnakeCaseMapper::class)]
-class Checkout extends Data
+class Checkout extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CheckoutBillingAddressFields.php
+++ b/src/Data/CheckoutBillingAddressFields.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\BillingAddressFieldMode;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutBillingAddressFields extends Data
+class CheckoutBillingAddressFields extends PolarData
 {
     public function __construct(
         public readonly BillingAddressFieldMode $country,

--- a/src/Data/CheckoutCreate.php
+++ b/src/Data/CheckoutCreate.php
@@ -6,9 +6,9 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutCreate extends Data {}
+class CheckoutCreate extends PolarData {}

--- a/src/Data/CheckoutDiscountFixedOnceForeverDuration.php
+++ b/src/Data/CheckoutDiscountFixedOnceForeverDuration.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema for a fixed amount discount that is applied once or forever.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutDiscountFixedOnceForeverDuration extends Data
+class CheckoutDiscountFixedOnceForeverDuration extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/CheckoutDiscountFixedRepeatDuration.php
+++ b/src/Data/CheckoutDiscountFixedRepeatDuration.php
@@ -8,8 +8,8 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * for a certain number of months.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutDiscountFixedRepeatDuration extends Data
+class CheckoutDiscountFixedRepeatDuration extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/CheckoutDiscountPercentageOnceForeverDuration.php
+++ b/src/Data/CheckoutDiscountPercentageOnceForeverDuration.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema for a percentage discount that is applied once or forever.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutDiscountPercentageOnceForeverDuration extends Data
+class CheckoutDiscountPercentageOnceForeverDuration extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/CheckoutDiscountPercentageRepeatDuration.php
+++ b/src/Data/CheckoutDiscountPercentageRepeatDuration.php
@@ -8,8 +8,8 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * for a certain number of months.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutDiscountPercentageRepeatDuration extends Data
+class CheckoutDiscountPercentageRepeatDuration extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/CheckoutLink.php
+++ b/src/Data/CheckoutLink.php
@@ -9,15 +9,15 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\PaymentProcessor;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Checkout link data.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutLink extends Data
+class CheckoutLink extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CheckoutLinkCreateProduct.php
+++ b/src/Data/CheckoutLinkCreateProduct.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Deprecated**: Use `CheckoutLinkCreateProducts` instead.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutLinkCreateProduct extends Data implements CheckoutLinkCreate
+class CheckoutLinkCreateProduct extends PolarData implements CheckoutLinkCreate
 {
     public function __construct(
         public readonly string $productId,

--- a/src/Data/CheckoutLinkCreateProductPrice.php
+++ b/src/Data/CheckoutLinkCreateProductPrice.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Deprecated**: Use `CheckoutLinkCreateProducts` instead.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutLinkCreateProductPrice extends Data implements CheckoutLinkCreate
+class CheckoutLinkCreateProductPrice extends PolarData implements CheckoutLinkCreate
 {
     public function __construct(
         public readonly string $productPriceId,

--- a/src/Data/CheckoutLinkCreateProducts.php
+++ b/src/Data/CheckoutLinkCreateProducts.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a new checkout link.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutLinkCreateProducts extends Data implements CheckoutLinkCreate
+class CheckoutLinkCreateProducts extends PolarData implements CheckoutLinkCreate
 {
     public function __construct(
         /**

--- a/src/Data/CheckoutLinkProduct.php
+++ b/src/Data/CheckoutLinkProduct.php
@@ -10,15 +10,15 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductVisibility;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Product data for a checkout link.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutLinkProduct extends Data
+class CheckoutLinkProduct extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CheckoutLinkUpdate.php
+++ b/src/Data/CheckoutLinkUpdate.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update an existing checkout link.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutLinkUpdate extends Data
+class CheckoutLinkUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CheckoutProduct.php
+++ b/src/Data/CheckoutProduct.php
@@ -10,15 +10,15 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductVisibility;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Product data for a checkout session.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutProduct extends Data
+class CheckoutProduct extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CheckoutProductsCreate.php
+++ b/src/Data/CheckoutProductsCreate.php
@@ -8,8 +8,8 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -20,7 +20,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * to the resulting order and/or subscription.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CheckoutProductsCreate extends Data
+class CheckoutProductsCreate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CostMetadataInput.php
+++ b/src/Data/CostMetadataInput.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CostMetadataInput extends Data
+class CostMetadataInput extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CountAggregation.php
+++ b/src/Data/CountAggregation.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CountAggregation extends Data
+class CountAggregation extends PolarData
 {
     public function __construct(
         public readonly string $func = 'count',

--- a/src/Data/CustomField.php
+++ b/src/Data/CustomField.php
@@ -7,14 +7,14 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class CustomField extends Data implements PropertyMorphableData
+abstract class CustomField extends PolarData implements PropertyMorphableData
 {
     /**
      * Creation timestamp of the object.

--- a/src/Data/CustomFieldCheckboxProperties.php
+++ b/src/Data/CustomFieldCheckboxProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldCheckboxProperties extends Data
+class CustomFieldCheckboxProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $formLabel = null,

--- a/src/Data/CustomFieldCreateCheckbox.php
+++ b/src/Data/CustomFieldCreateCheckbox.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a custom field of type checkbox.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldCreateCheckbox extends Data implements CustomFieldCreate
+class CustomFieldCreateCheckbox extends PolarData implements CustomFieldCreate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldCreateDate.php
+++ b/src/Data/CustomFieldCreateDate.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a custom field of type date.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldCreateDate extends Data implements CustomFieldCreate
+class CustomFieldCreateDate extends PolarData implements CustomFieldCreate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldCreateNumber.php
+++ b/src/Data/CustomFieldCreateNumber.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a custom field of type number.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldCreateNumber extends Data implements CustomFieldCreate
+class CustomFieldCreateNumber extends PolarData implements CustomFieldCreate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldCreateSelect.php
+++ b/src/Data/CustomFieldCreateSelect.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a custom field of type select.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldCreateSelect extends Data implements CustomFieldCreate
+class CustomFieldCreateSelect extends PolarData implements CustomFieldCreate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldCreateText.php
+++ b/src/Data/CustomFieldCreateText.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a custom field of type text.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldCreateText extends Data implements CustomFieldCreate
+class CustomFieldCreateText extends PolarData implements CustomFieldCreate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldDateProperties.php
+++ b/src/Data/CustomFieldDateProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldDateProperties extends Data
+class CustomFieldDateProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $formLabel = null,

--- a/src/Data/CustomFieldNumberProperties.php
+++ b/src/Data/CustomFieldNumberProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldNumberProperties extends Data
+class CustomFieldNumberProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $formLabel = null,

--- a/src/Data/CustomFieldSelectOption.php
+++ b/src/Data/CustomFieldSelectOption.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldSelectOption extends Data
+class CustomFieldSelectOption extends PolarData
 {
     public function __construct(
         public readonly string $value,

--- a/src/Data/CustomFieldSelectProperties.php
+++ b/src/Data/CustomFieldSelectProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldSelectProperties extends Data
+class CustomFieldSelectProperties extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldTextProperties.php
+++ b/src/Data/CustomFieldTextProperties.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldTextProperties extends Data
+class CustomFieldTextProperties extends PolarData
 {
     public function __construct(
         public readonly ?string $formLabel = null,

--- a/src/Data/CustomFieldUpdateCheckbox.php
+++ b/src/Data/CustomFieldUpdateCheckbox.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update a custom field of type checkbox.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldUpdateCheckbox extends Data implements CustomFieldUpdate
+class CustomFieldUpdateCheckbox extends PolarData implements CustomFieldUpdate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldUpdateDate.php
+++ b/src/Data/CustomFieldUpdateDate.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update a custom field of type date.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldUpdateDate extends Data implements CustomFieldUpdate
+class CustomFieldUpdateDate extends PolarData implements CustomFieldUpdate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldUpdateNumber.php
+++ b/src/Data/CustomFieldUpdateNumber.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update a custom field of type number.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldUpdateNumber extends Data implements CustomFieldUpdate
+class CustomFieldUpdateNumber extends PolarData implements CustomFieldUpdate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldUpdateSelect.php
+++ b/src/Data/CustomFieldUpdateSelect.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update a custom field of type select.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldUpdateSelect extends Data implements CustomFieldUpdate
+class CustomFieldUpdateSelect extends PolarData implements CustomFieldUpdate
 {
     public function __construct(
         /**

--- a/src/Data/CustomFieldUpdateText.php
+++ b/src/Data/CustomFieldUpdateText.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update a custom field of type text.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomFieldUpdateText extends Data implements CustomFieldUpdate
+class CustomFieldUpdateText extends PolarData implements CustomFieldUpdate
 {
     public function __construct(
         /**

--- a/src/Data/Customer.php
+++ b/src/Data/Customer.php
@@ -7,14 +7,14 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class Customer extends Data implements PropertyMorphableData
+abstract class Customer extends PolarData implements PropertyMorphableData
 {
     /**
      * The ID of the customer.

--- a/src/Data/CustomerMeter.php
+++ b/src/Data/CustomerMeter.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * An active customer meter, with current consumed and credited units.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerMeter extends Data
+class CustomerMeter extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerOrderInvoice.php
+++ b/src/Data/CustomerOrderInvoice.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Order's invoice data.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerOrderInvoice extends Data
+class CustomerOrderInvoice extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerPaymentMethod.php
+++ b/src/Data/CustomerPaymentMethod.php
@@ -8,14 +8,14 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\PaymentProcessor;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class CustomerPaymentMethod extends Data implements PropertyMorphableData
+abstract class CustomerPaymentMethod extends PolarData implements PropertyMorphableData
 {
     /**
      * The ID of the object.

--- a/src/Data/CustomerPortalCustomerSettings.php
+++ b/src/Data/CustomerPortalCustomerSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomerPortalCustomerSettings extends Data
+class CustomerPortalCustomerSettings extends PolarData
 {
     public function __construct(
         public readonly ?bool $allowEmailChange = null,

--- a/src/Data/CustomerPortalSubscriptionSettings.php
+++ b/src/Data/CustomerPortalSubscriptionSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomerPortalSubscriptionSettings extends Data
+class CustomerPortalSubscriptionSettings extends PolarData
 {
     public function __construct(
         public readonly bool $updateSeats,

--- a/src/Data/CustomerPortalUsageSettings.php
+++ b/src/Data/CustomerPortalUsageSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomerPortalUsageSettings extends Data
+class CustomerPortalUsageSettings extends PolarData
 {
     public function __construct(
         public readonly bool $show,

--- a/src/Data/CustomerSeat.php
+++ b/src/Data/CustomerSeat.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\SeatStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class CustomerSeat extends Data
+class CustomerSeat extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerSession.php
+++ b/src/Data/CustomerSession.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * A customer session that can be used to authenticate as a customer.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerSession extends Data
+class CustomerSession extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerSessionCustomerExternalIDCreate.php
+++ b/src/Data/CustomerSessionCustomerExternalIDCreate.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema for creating a customer session using an external customer ID.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerSessionCustomerExternalIDCreate extends Data
+class CustomerSessionCustomerExternalIDCreate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerSessionCustomerIDCreate.php
+++ b/src/Data/CustomerSessionCustomerIDCreate.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema for creating a customer session using a customer ID.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerSessionCustomerIDCreate extends Data
+class CustomerSessionCustomerIDCreate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerState.php
+++ b/src/Data/CustomerState.php
@@ -7,14 +7,14 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class CustomerState extends Data implements PropertyMorphableData
+abstract class CustomerState extends PolarData implements PropertyMorphableData
 {
     /**
      * The ID of the customer.

--- a/src/Data/CustomerStateBenefitGrant.php
+++ b/src/Data/CustomerStateBenefitGrant.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\BenefitType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * An active benefit grant for a customer.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerStateBenefitGrant extends Data
+class CustomerStateBenefitGrant extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerStateMeter.php
+++ b/src/Data/CustomerStateMeter.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * An active meter for a customer, with latest consumed and credited units.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerStateMeter extends Data
+class CustomerStateMeter extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerStateSubscription.php
+++ b/src/Data/CustomerStateSubscription.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * An active customer subscription.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerStateSubscription extends Data
+class CustomerStateSubscription extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/CustomerStateSubscriptionMeter.php
+++ b/src/Data/CustomerStateSubscriptionMeter.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Current consumption and spending for a subscription meter.
  */
 #[MapName(SnakeCaseMapper::class)]
-class CustomerStateSubscriptionMeter extends Data
+class CustomerStateSubscriptionMeter extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Discount.php
+++ b/src/Data/Discount.php
@@ -9,14 +9,14 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class Discount extends Data implements PropertyMorphableData
+abstract class Discount extends PolarData implements PropertyMorphableData
 {
     #[PropertyForMorph]
     public DiscountDuration $duration;

--- a/src/Data/DiscountFixedCreate.php
+++ b/src/Data/DiscountFixedCreate.php
@@ -9,15 +9,15 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a fixed amount discount.
  */
 #[MapName(SnakeCaseMapper::class)]
-class DiscountFixedCreate extends Data implements DiscountCreate
+class DiscountFixedCreate extends PolarData implements DiscountCreate
 {
     public function __construct(
         /**

--- a/src/Data/DiscountFixedOnceForeverDurationBase.php
+++ b/src/Data/DiscountFixedOnceForeverDurationBase.php
@@ -9,12 +9,12 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class DiscountFixedOnceForeverDurationBase extends Data
+class DiscountFixedOnceForeverDurationBase extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/DiscountFixedRepeatDurationBase.php
+++ b/src/Data/DiscountFixedRepeatDurationBase.php
@@ -9,12 +9,12 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class DiscountFixedRepeatDurationBase extends Data
+class DiscountFixedRepeatDurationBase extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/DiscountPercentageCreate.php
+++ b/src/Data/DiscountPercentageCreate.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a percentage discount.
  */
 #[MapName(SnakeCaseMapper::class)]
-class DiscountPercentageCreate extends Data implements DiscountCreate
+class DiscountPercentageCreate extends PolarData implements DiscountCreate
 {
     public function __construct(
         /**

--- a/src/Data/DiscountPercentageOnceForeverDurationBase.php
+++ b/src/Data/DiscountPercentageOnceForeverDurationBase.php
@@ -9,12 +9,12 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class DiscountPercentageOnceForeverDurationBase extends Data
+class DiscountPercentageOnceForeverDurationBase extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/DiscountPercentageRepeatDurationBase.php
+++ b/src/Data/DiscountPercentageRepeatDurationBase.php
@@ -9,12 +9,12 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class DiscountPercentageRepeatDurationBase extends Data
+class DiscountPercentageRepeatDurationBase extends PolarData
 {
     public function __construct(
         public readonly DiscountDuration $duration,

--- a/src/Data/DiscountProduct.php
+++ b/src/Data/DiscountProduct.php
@@ -10,15 +10,15 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductVisibility;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * A product that a discount can be applied to.
  */
 #[MapName(SnakeCaseMapper::class)]
-class DiscountProduct extends Data
+class DiscountProduct extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/DiscountUpdate.php
+++ b/src/Data/DiscountUpdate.php
@@ -10,15 +10,15 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DiscountDuration;
 use Danestves\LaravelPolar\Enums\DiscountType;
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to update a discount.
  */
 #[MapName(SnakeCaseMapper::class)]
-class DiscountUpdate extends Data
+class DiscountUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/EventCreateCustomer.php
+++ b/src/Data/EventCreateCustomer.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class EventCreateCustomer extends Data
+class EventCreateCustomer extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/EventCreateExternalCustomer.php
+++ b/src/Data/EventCreateExternalCustomer.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class EventCreateExternalCustomer extends Data
+class EventCreateExternalCustomer extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/EventMetadataInput.php
+++ b/src/Data/EventMetadataInput.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class EventMetadataInput extends Data
+class EventMetadataInput extends PolarData
 {
     public function __construct(
         public readonly ?CostMetadataInput $cost = null,

--- a/src/Data/EventsIngest.php
+++ b/src/Data/EventsIngest.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class EventsIngest extends Data
+class EventsIngest extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/EventsIngestResponse.php
+++ b/src/Data/EventsIngestResponse.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class EventsIngestResponse extends Data
+class EventsIngestResponse extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/FileRead.php
+++ b/src/Data/FileRead.php
@@ -7,14 +7,14 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class FileRead extends Data implements PropertyMorphableData
+abstract class FileRead extends PolarData implements PropertyMorphableData
 {
     /**
      * The ID of the object.

--- a/src/Data/Filter.php
+++ b/src/Data/Filter.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\FilterConjunction;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Filter extends Data
+class Filter extends PolarData
 {
     public function __construct(
         public readonly FilterConjunction $conjunction,

--- a/src/Data/FilterClause.php
+++ b/src/Data/FilterClause.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\FilterOperator;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class FilterClause extends Data
+class FilterClause extends PolarData
 {
     public function __construct(
         public readonly string $property,

--- a/src/Data/LLMMetadata.php
+++ b/src/Data/LLMMetadata.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LLMMetadata extends Data
+class LLMMetadata extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/LegacyRecurringProductPrice.php
+++ b/src/Data/LegacyRecurringProductPrice.php
@@ -10,14 +10,14 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductPriceSource;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class LegacyRecurringProductPrice extends Data implements PropertyMorphableData
+abstract class LegacyRecurringProductPrice extends PolarData implements PropertyMorphableData
 {
     /**
      * Creation timestamp of the object.

--- a/src/Data/LicenseKeyActivate.php
+++ b/src/Data/LicenseKeyActivate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyActivate extends Data
+class LicenseKeyActivate extends PolarData
 {
     public function __construct(
         public readonly string $key,

--- a/src/Data/LicenseKeyActivationBase.php
+++ b/src/Data/LicenseKeyActivationBase.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyActivationBase extends Data
+class LicenseKeyActivationBase extends PolarData
 {
     public function __construct(
         public readonly string $id,

--- a/src/Data/LicenseKeyActivationRead.php
+++ b/src/Data/LicenseKeyActivationRead.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyActivationRead extends Data
+class LicenseKeyActivationRead extends PolarData
 {
     public function __construct(
         public readonly string $id,

--- a/src/Data/LicenseKeyCustomer.php
+++ b/src/Data/LicenseKeyCustomer.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\CustomerType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyCustomer extends Data
+class LicenseKeyCustomer extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/LicenseKeyDeactivate.php
+++ b/src/Data/LicenseKeyDeactivate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyDeactivate extends Data
+class LicenseKeyDeactivate extends PolarData
 {
     public function __construct(
         public readonly string $key,

--- a/src/Data/LicenseKeyRead.php
+++ b/src/Data/LicenseKeyRead.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\LicenseKeyStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyRead extends Data
+class LicenseKeyRead extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/LicenseKeyUpdate.php
+++ b/src/Data/LicenseKeyUpdate.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\LicenseKeyStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyUpdate extends Data
+class LicenseKeyUpdate extends PolarData
 {
     public function __construct(
         public readonly ?LicenseKeyStatus $status = null,

--- a/src/Data/LicenseKeyValidate.php
+++ b/src/Data/LicenseKeyValidate.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyValidate extends Data
+class LicenseKeyValidate extends PolarData
 {
     public function __construct(
         public readonly string $key,

--- a/src/Data/LicenseKeyWithActivations.php
+++ b/src/Data/LicenseKeyWithActivations.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\LicenseKeyStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class LicenseKeyWithActivations extends Data
+class LicenseKeyWithActivations extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Member.php
+++ b/src/Data/Member.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\MemberRole;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * A member of a customer.
  */
 #[MapName(SnakeCaseMapper::class)]
-class Member extends Data
+class Member extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/MetadataOutputType.php
+++ b/src/Data/MetadataOutputType.php
@@ -6,9 +6,9 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class MetadataOutputType extends Data {}
+class MetadataOutputType extends PolarData {}

--- a/src/Data/Meter.php
+++ b/src/Data/Meter.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\MeterUnit;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Meter extends Data
+class Meter extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Metric.php
+++ b/src/Data/Metric.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\MetricType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Information about a metric.
  */
 #[MapName(SnakeCaseMapper::class)]
-class Metric extends Data
+class Metric extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/MetricPeriod.php
+++ b/src/Data/MetricPeriod.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class MetricPeriod extends Data
+class MetricPeriod extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Metrics.php
+++ b/src/Data/Metrics.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Metrics extends Data
+class Metrics extends PolarData
 {
     public function __construct(
         public readonly ?Metric $activeSubscriptions = null,

--- a/src/Data/MetricsResponse.php
+++ b/src/Data/MetricsResponse.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Metrics response schema.
  */
 #[MapName(SnakeCaseMapper::class)]
-class MetricsResponse extends Data
+class MetricsResponse extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/MetricsTotals.php
+++ b/src/Data/MetricsTotals.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class MetricsTotals extends Data
+class MetricsTotals extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Order.php
+++ b/src/Data/Order.php
@@ -9,12 +9,12 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\OrderBillingReason;
 use Danestves\LaravelPolar\Enums\OrderStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Order extends Data
+class Order extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrderCustomer.php
+++ b/src/Data/OrderCustomer.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\CustomerType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrderCustomer extends Data
+class OrderCustomer extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrderItemSchema.php
+++ b/src/Data/OrderItemSchema.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * An order line item.
  */
 #[MapName(SnakeCaseMapper::class)]
-class OrderItemSchema extends Data
+class OrderItemSchema extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrderProduct.php
+++ b/src/Data/OrderProduct.php
@@ -10,12 +10,12 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductVisibility;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrderProduct extends Data
+class OrderProduct extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrderSubscription.php
+++ b/src/Data/OrderSubscription.php
@@ -10,12 +10,12 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\CustomerCancellationReason;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\SubscriptionStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrderSubscription extends Data
+class OrderSubscription extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Organization.php
+++ b/src/Data/Organization.php
@@ -10,12 +10,12 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\OrganizationStatus;
 use Danestves\LaravelPolar\Enums\SubscriptionProrationBehavior;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Organization extends Data
+class Organization extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrganizationCapabilities.php
+++ b/src/Data/OrganizationCapabilities.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationCapabilities extends Data
+class OrganizationCapabilities extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrganizationCustomerEmailSettings.php
+++ b/src/Data/OrganizationCustomerEmailSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationCustomerEmailSettings extends Data
+class OrganizationCustomerEmailSettings extends PolarData
 {
     public function __construct(
         public readonly bool $orderConfirmation,

--- a/src/Data/OrganizationCustomerPortalSettings.php
+++ b/src/Data/OrganizationCustomerPortalSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationCustomerPortalSettings extends Data
+class OrganizationCustomerPortalSettings extends PolarData
 {
     public function __construct(
         public readonly CustomerPortalUsageSettings $usage,

--- a/src/Data/OrganizationDisputeSettings.php
+++ b/src/Data/OrganizationDisputeSettings.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * `auto_accept_below_amount` is in Polar's settlement currency (USD).
  */
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationDisputeSettings extends Data
+class OrganizationDisputeSettings extends PolarData
 {
     public function __construct(
         public readonly ?int $autoAcceptBelowAmount,

--- a/src/Data/OrganizationFeatureSettings.php
+++ b/src/Data/OrganizationFeatureSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationFeatureSettings extends Data
+class OrganizationFeatureSettings extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrganizationSocialLink.php
+++ b/src/Data/OrganizationSocialLink.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\OrganizationSocialPlatforms;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationSocialLink extends Data
+class OrganizationSocialLink extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/OrganizationSubscriptionSettings.php
+++ b/src/Data/OrganizationSubscriptionSettings.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class OrganizationSubscriptionSettings extends Data
+class OrganizationSubscriptionSettings extends PolarData
 {
     public function __construct(
         public readonly bool $allowMultipleSubscriptions,

--- a/src/Data/Pagination.php
+++ b/src/Data/Pagination.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Pagination extends Data
+class Pagination extends PolarData
 {
     public function __construct(
         public readonly int $totalCount,

--- a/src/Data/PaymentMethodCardMetadata.php
+++ b/src/Data/PaymentMethodCardMetadata.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class PaymentMethodCardMetadata extends Data
+class PaymentMethodCardMetadata extends PolarData
 {
     public function __construct(
         public readonly string $brand,

--- a/src/Data/PendingSubscriptionUpdate.php
+++ b/src/Data/PendingSubscriptionUpdate.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Pending update to be applied to a subscription at the beginning of the next period.
  */
 #[MapName(SnakeCaseMapper::class)]
-class PendingSubscriptionUpdate extends Data
+class PendingSubscriptionUpdate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Product.php
+++ b/src/Data/Product.php
@@ -10,15 +10,15 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductVisibility;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\TrialInterval;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * A product.
  */
 #[MapName(SnakeCaseMapper::class)]
-class Product extends Data
+class Product extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPrice.php
+++ b/src/Data/ProductPrice.php
@@ -9,14 +9,14 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\ProductPriceSource;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-abstract class ProductPrice extends Data implements PropertyMorphableData
+abstract class ProductPrice extends PolarData implements PropertyMorphableData
 {
     /**
      * Creation timestamp of the object.

--- a/src/Data/ProductPriceCustomCreate.php
+++ b/src/Data/ProductPriceCustomCreate.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a pay-what-you-want price.
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceCustomCreate extends Data
+class ProductPriceCustomCreate extends PolarData
 {
     public function __construct(
         public readonly string $amountType = 'custom',

--- a/src/Data/ProductPriceFixedCreate.php
+++ b/src/Data/ProductPriceFixedCreate.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a fixed price.
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceFixedCreate extends Data
+class ProductPriceFixedCreate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPriceMeter.php
+++ b/src/Data/ProductPriceMeter.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\MeterUnit;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * A meter associated to a metered price.
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceMeter extends Data
+class ProductPriceMeter extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPriceMeteredUnitCreate.php
+++ b/src/Data/ProductPriceMeteredUnitCreate.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a metered price with a fixed unit price.
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceMeteredUnitCreate extends Data
+class ProductPriceMeteredUnitCreate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPriceSeatBasedCreate.php
+++ b/src/Data/ProductPriceSeatBasedCreate.php
@@ -8,15 +8,15 @@ namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\PresentmentCurrency;
 use Danestves\LaravelPolar\Enums\TaxBehaviorOption;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Schema to create a seat-based price with volume-based tiers.
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceSeatBasedCreate extends Data
+class ProductPriceSeatBasedCreate extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPriceSeatTier.php
+++ b/src/Data/ProductPriceSeatTier.php
@@ -6,15 +6,15 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * A pricing tier for seat-based pricing.
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceSeatTier extends Data
+class ProductPriceSeatTier extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPriceSeatTiersInput.php
+++ b/src/Data/ProductPriceSeatTiersInput.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\SeatTierType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -19,7 +19,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * - maximum_seats = last tier's max_seats (None for unlimited)
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceSeatTiersInput extends Data
+class ProductPriceSeatTiersInput extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/ProductPriceSeatTiersOutput.php
+++ b/src/Data/ProductPriceSeatTiersOutput.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\SeatTierType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -19,7 +19,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * - maximum_seats = last tier's max_seats (None for unlimited)
  */
 #[MapName(SnakeCaseMapper::class)]
-class ProductPriceSeatTiersOutput extends Data
+class ProductPriceSeatTiersOutput extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/PropertyAggregation.php
+++ b/src/Data/PropertyAggregation.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class PropertyAggregation extends Data
+class PropertyAggregation extends PolarData
 {
     public function __construct(
         public readonly string $func,

--- a/src/Data/Refund.php
+++ b/src/Data/Refund.php
@@ -9,12 +9,12 @@ namespace Danestves\LaravelPolar\Data;
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\RefundReason;
 use Danestves\LaravelPolar\Enums\RefundStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Refund extends Data
+class Refund extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/RefundCreate.php
+++ b/src/Data/RefundCreate.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\RefundCreateReason;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class RefundCreate extends Data
+class RefundCreate extends PolarData
 {
     public function __construct(
         public readonly string $orderId,

--- a/src/Data/RefundDispute.php
+++ b/src/Data/RefundDispute.php
@@ -8,8 +8,8 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\DisputeStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * in case we prevented a dispute by issuing a refund.
  */
 #[MapName(SnakeCaseMapper::class)]
-class RefundDispute extends Data
+class RefundDispute extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/SeatAssign.php
+++ b/src/Data/SeatAssign.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SeatAssign extends Data
+class SeatAssign extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/SeatsList.php
+++ b/src/Data/SeatsList.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SeatsList extends Data
+class SeatsList extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/Subscription.php
+++ b/src/Data/Subscription.php
@@ -10,12 +10,12 @@ use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\CustomerCancellationReason;
 use Danestves\LaravelPolar\Enums\RecurringInterval;
 use Danestves\LaravelPolar\Enums\SubscriptionStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class Subscription extends Data
+class Subscription extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionCancel.php
+++ b/src/Data/SubscriptionCancel.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\CustomerCancellationReason;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionCancel extends Data implements SubscriptionUpdate
+class SubscriptionCancel extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionCustomer.php
+++ b/src/Data/SubscriptionCustomer.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\CustomerType;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionCustomer extends Data
+class SubscriptionCustomer extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionMeter.php
+++ b/src/Data/SubscriptionMeter.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
  * Current consumption and spending for a subscription meter.
  */
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionMeter extends Data
+class SubscriptionMeter extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionPause.php
+++ b/src/Data/SubscriptionPause.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionPause extends Data implements SubscriptionUpdate
+class SubscriptionPause extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionResume.php
+++ b/src/Data/SubscriptionResume.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionResume extends Data implements SubscriptionUpdate
+class SubscriptionResume extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionRevoke.php
+++ b/src/Data/SubscriptionRevoke.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\CustomerCancellationReason;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionRevoke extends Data implements SubscriptionUpdate
+class SubscriptionRevoke extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionUpdateBase.php
+++ b/src/Data/SubscriptionUpdateBase.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\SubscriptionProrationBehavior;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionUpdateBase extends Data implements SubscriptionUpdate
+class SubscriptionUpdateBase extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionUpdateBillingPeriod.php
+++ b/src/Data/SubscriptionUpdateBillingPeriod.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionUpdateBillingPeriod extends Data implements SubscriptionUpdate
+class SubscriptionUpdateBillingPeriod extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionUpdateClear.php
+++ b/src/Data/SubscriptionUpdateClear.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionUpdateClear extends Data implements SubscriptionUpdate
+class SubscriptionUpdateClear extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/SubscriptionUpdateSeats.php
+++ b/src/Data/SubscriptionUpdateSeats.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Danestves\LaravelPolar\Enums\SubscriptionProrationBehavior;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class SubscriptionUpdateSeats extends Data implements SubscriptionUpdate
+class SubscriptionUpdateSeats extends PolarData implements SubscriptionUpdate
 {
     public function __construct(
         /**

--- a/src/Data/UniqueAggregation.php
+++ b/src/Data/UniqueAggregation.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
 
 namespace Danestves\LaravelPolar\Data;
 
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class UniqueAggregation extends Data
+class UniqueAggregation extends PolarData
 {
     public function __construct(
         public readonly string $property,

--- a/src/Data/ValidatedLicenseKey.php
+++ b/src/Data/ValidatedLicenseKey.php
@@ -8,12 +8,12 @@ namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
 use Danestves\LaravelPolar\Enums\LicenseKeyStatus;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 #[MapName(SnakeCaseMapper::class)]
-class ValidatedLicenseKey extends Data
+class ValidatedLicenseKey extends PolarData
 {
     public function __construct(
         /**

--- a/src/Data/WebhookBenefitCreatedPayload.php
+++ b/src/Data/WebhookBenefitCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookBenefitCreatedPayload extends Data
+class WebhookBenefitCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookBenefitGrantCreatedPayload.php
+++ b/src/Data/WebhookBenefitGrantCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookBenefitGrantCreatedPayload extends Data
+class WebhookBenefitGrantCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookBenefitGrantRevokedPayload.php
+++ b/src/Data/WebhookBenefitGrantRevokedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookBenefitGrantRevokedPayload extends Data
+class WebhookBenefitGrantRevokedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookBenefitGrantUpdatedPayload.php
+++ b/src/Data/WebhookBenefitGrantUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookBenefitGrantUpdatedPayload extends Data
+class WebhookBenefitGrantUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookBenefitUpdatedPayload.php
+++ b/src/Data/WebhookBenefitUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookBenefitUpdatedPayload extends Data
+class WebhookBenefitUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCheckoutCreatedPayload.php
+++ b/src/Data/WebhookCheckoutCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCheckoutCreatedPayload extends Data
+class WebhookCheckoutCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCheckoutExpiredPayload.php
+++ b/src/Data/WebhookCheckoutExpiredPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -20,7 +20,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCheckoutExpiredPayload extends Data
+class WebhookCheckoutExpiredPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCheckoutUpdatedPayload.php
+++ b/src/Data/WebhookCheckoutUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCheckoutUpdatedPayload extends Data
+class WebhookCheckoutUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCustomerCreatedPayload.php
+++ b/src/Data/WebhookCustomerCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -22,7 +22,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCustomerCreatedPayload extends Data
+class WebhookCustomerCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCustomerDeletedPayload.php
+++ b/src/Data/WebhookCustomerDeletedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCustomerDeletedPayload extends Data
+class WebhookCustomerDeletedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCustomerStateChangedPayload.php
+++ b/src/Data/WebhookCustomerStateChangedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -23,7 +23,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCustomerStateChangedPayload extends Data
+class WebhookCustomerStateChangedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookCustomerUpdatedPayload.php
+++ b/src/Data/WebhookCustomerUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -22,7 +22,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookCustomerUpdatedPayload extends Data
+class WebhookCustomerUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookOrderCreatedPayload.php
+++ b/src/Data/WebhookOrderCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -29,7 +29,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Full
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookOrderCreatedPayload extends Data
+class WebhookOrderCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookOrderUpdatedPayload.php
+++ b/src/Data/WebhookOrderUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -22,7 +22,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Full
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookOrderUpdatedPayload extends Data
+class WebhookOrderUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookProductCreatedPayload.php
+++ b/src/Data/WebhookProductCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookProductCreatedPayload extends Data
+class WebhookProductCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookProductUpdatedPayload.php
+++ b/src/Data/WebhookProductUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -17,7 +17,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Basic
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookProductUpdatedPayload extends Data
+class WebhookProductUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookSubscriptionActivePayload.php
+++ b/src/Data/WebhookSubscriptionActivePayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -18,7 +18,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Full
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookSubscriptionActivePayload extends Data
+class WebhookSubscriptionActivePayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookSubscriptionCanceledPayload.php
+++ b/src/Data/WebhookSubscriptionCanceledPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -18,7 +18,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Full
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookSubscriptionCanceledPayload extends Data
+class WebhookSubscriptionCanceledPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookSubscriptionCreatedPayload.php
+++ b/src/Data/WebhookSubscriptionCreatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -20,7 +20,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Full
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookSubscriptionCreatedPayload extends Data
+class WebhookSubscriptionCreatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookSubscriptionRevokedPayload.php
+++ b/src/Data/WebhookSubscriptionRevokedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -21,7 +21,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** Full
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookSubscriptionRevokedPayload extends Data
+class WebhookSubscriptionRevokedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Data/WebhookSubscriptionUpdatedPayload.php
+++ b/src/Data/WebhookSubscriptionUpdatedPayload.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 namespace Danestves\LaravelPolar\Data;
 
 use Carbon\CarbonImmutable;
+use Danestves\LaravelPolar\Support\PolarData;
 use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
 /**
@@ -23,7 +23,7 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
  * **Discord & Slack support:** On cancellation, past due, and revocation. Renewals are skipped.
  */
 #[MapName(SnakeCaseMapper::class)]
-class WebhookSubscriptionUpdatedPayload extends Data
+class WebhookSubscriptionUpdatedPayload extends PolarData
 {
     public function __construct(
         public readonly CarbonImmutable $timestamp,

--- a/src/Support/PolarData.php
+++ b/src/Support/PolarData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Danestves\LaravelPolar\Support;
+
+use DateTimeInterface;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Support\Creation\CreationContext;
+use Spatie\LaravelData\Support\Creation\CreationContextFactory;
+
+abstract class PolarData extends Data
+{
+    /**
+     * Build Polar data with support for every timestamp format returned by the API.
+     */
+    public static function factory(?CreationContext $creationContext = null): CreationContextFactory
+    {
+        return parent::factory($creationContext)->withCast(
+            DateTimeInterface::class,
+            new DateTimeInterfaceCast([
+                DATE_ATOM,
+                'Y-m-d\TH:i:s.uP',
+            ]),
+        );
+    }
+}

--- a/tests/Unit/ProductPriceTest.php
+++ b/tests/Unit/ProductPriceTest.php
@@ -2,6 +2,20 @@
 
 use Danestves\LaravelPolar\Data;
 
+it('hydrates Polar timestamps with microseconds', function () {
+    $product = Data\Product::from(polarFixture('Product', [
+        'created_at' => '2025-11-18T04:35:00.230607Z',
+        'modified_at' => '2026-01-14T17:04:58.235496Z',
+        'prices' => [polarFixture('ProductPriceFixed', [
+            'created_at' => '2025-12-04T12:51:41.000739Z',
+        ])],
+    ]));
+
+    expect($product->createdAt->format('Y-m-d H:i:s.u'))->toBe('2025-11-18 04:35:00.230607')
+        ->and($product->modifiedAt?->format('Y-m-d H:i:s.u'))->toBe('2026-01-14 17:04:58.235496')
+        ->and($product->prices[0]->createdAt->format('Y-m-d H:i:s.u'))->toBe('2025-12-04 12:51:41.000739');
+});
+
 /**
  * Polar returns prices as `LegacyRecurringProductPrice|ProductPrice`, and both halves of that
  * union discriminate on `amount_type`. laravel-data only ever asks the first class in a union

--- a/tools/generate-data.php
+++ b/tools/generate-data.php
@@ -615,8 +615,8 @@ final class DataGenerator
         $shared = $this->sharedProperties($members);
 
         $uses = [
+            'Danestves\\LaravelPolar\\Support\\PolarData',
             'Spatie\\LaravelData\\Attributes\\MapName',
-            'Spatie\\LaravelData\\Data',
             'Spatie\\LaravelData\\Mappers\\SnakeCaseMapper',
         ];
 
@@ -700,7 +700,7 @@ final class DataGenerator
 
         {$usesBody}
         {$doc}#[MapName(SnakeCaseMapper::class)]
-        abstract class {$class} extends Data{$implements}
+        abstract class {$class} extends PolarData{$implements}
         {
         {$propsBody}{$methodsBody}
         }
@@ -750,8 +750,8 @@ final class DataGenerator
             $skip = array_keys($this->baseProperties($parent, $parentMembers));
             $extends = $this->className($parent);
         } else {
-            $uses[] = 'Spatie\\LaravelData\\Data';
-            $extends = 'Data';
+            $uses[] = 'Danestves\\LaravelPolar\\Support\\PolarData';
+            $extends = 'PolarData';
         }
 
         $implements = '';


### PR DESCRIPTION
## Summary

Fixes #92.

Polar API responses may contain timestamps with microseconds, for example:

```
2025-12-04T12:51:41.000739Z
```

These timestamps could not be hydrated by spatie/laravel-data because the generated DTOs only accepted the default DATE_ATOM format.

This PR:

- adds a package-specific PolarData base class;
- accepts both `DATE_ATOM` and `Y-m-d\TH:i:s.uP`;
- updates the OpenAPI generator so generated DTOs extend PolarData;
- regenerates the affected DTOs;
- adds a regression test covering top-level and nested timestamps with microseconds.

The application’s global data.date_format configuration is left unchanged.

## Testing

- [x] 228 tests passed (539 assertions)
- [x] PHPStan passed
- [x] Laravel Pint passed

Tested locally.