### PR TITLE
chore: bump version to 3.1.1

### DIFF
--- a/src/LaravelPolar.php
+++ b/src/LaravelPolar.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Data as SpatieData;
 
 class LaravelPolar
 {
-    public const string VERSION = '3.1.0';
+    public const string VERSION = '3.1.1';
 
     /**
      * The cached HTTP client.


### PR DESCRIPTION
## Summary

`main` carries the microseconds timestamp fix from #93 but `LaravelPolar::VERSION` still reports `3.1.0`. #93 came from an outside contributor, so it did not bump the constant the way our own PRs usually do.

This bumps it to `3.1.1` so the tag, the release, and the constant stay in sync.

Patch, not minor: the fix changes no public API and no dependency constraint.

---

Made with Claude Opus 5 via Claude Code.